### PR TITLE
Save states, nuevos textos de menus, make reset, make flash_test

### DIFF
--- a/1-menu-instalacion.sh
+++ b/1-menu-instalacion.sh
@@ -2,7 +2,7 @@
 #By julenvitoria
 
 INPUT=/tmp/$MENU.sh.$$
-consola="zelda"
+consola="mario"
 
 clear
 dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 1-menu-instalacion.sh Consola seleccionada = $consola ------------------" \

--- a/1-menu-instalacion.sh
+++ b/1-menu-instalacion.sh
@@ -2,7 +2,7 @@
 #By julenvitoria
 
 INPUT=/tmp/$MENU.sh.$$
-consola="mario"
+consola="zelda"
 
 clear
 dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 1-menu-instalacion.sh Consola seleccionada = $consola ------------------" \

--- a/2-menu-scene-mario.sh
+++ b/2-menu-scene-mario.sh
@@ -11,7 +11,7 @@ dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO
 --cancel-label Exit \
 --menu "Selecciona con las flechas la opcion deseada:" 10 120 15 \
    1 "Backup, restauracion y liberacion de la G&W $consola" \
-   2 "Instalacion Custom FirmWare (CFW) y RetroGo en G&W $consola" \
+   2 "Instalacion Custom FirmWare (CFW) y RetroGo y backup/restauracion de save states en G&W $consola" \
    3 "Generación roms Game&Watch" 2>"${INPUT}"
 menuitem=$(<"${INPUT}")
 case $menuitem in
@@ -25,6 +25,10 @@ case $menuitem in
     sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./scene/2.2.2-cfw-retro-go-1mb-$consola.sh
     sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./scene/2.2.3-cfw-retro-go-16mb-$consola.sh
     sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./scene/2.2.4-cfw-retro-go-64mb-$consola.sh
+    sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./2.2.1-save-state-$consola.sh
+    sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./2.2.2-save-state-$consola.sh
+    sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./2.2.3-save-state-$consola.sh
+    sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./2.2.4-save-state-$consola.sh
     ./scene/2.2-retro-go-$consola.sh
     ./2-menu-scene-$consola.sh
     clear;;

--- a/2-menu-scene-mario.sh
+++ b/2-menu-scene-mario.sh
@@ -22,13 +22,9 @@ case $menuitem in
   2)clear
     sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./scene/2.2-retro-go-$consola.sh
     sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./scene/2.2.1-solo-retro-go-$consola.sh
-	sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./scene/2.2.1-save-state-$consola.sh
     sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./scene/2.2.2-cfw-retro-go-1mb-$consola.sh
-	sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./scene/2.2.2-save-state-$consola.sh
     sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./scene/2.2.3-cfw-retro-go-16mb-$consola.sh
-	sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./scene/2.2.3-save-state-$consola.sh
     sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./scene/2.2.4-cfw-retro-go-64mb-$consola.sh
-	sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./scene/2.2.4-save-state-$consola.sh
     ./scene/2.2-retro-go-$consola.sh
     ./2-menu-scene-$consola.sh
     clear;;

--- a/2-menu-scene-mario.sh
+++ b/2-menu-scene-mario.sh
@@ -22,9 +22,13 @@ case $menuitem in
   2)clear
     sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./scene/2.2-retro-go-$consola.sh
     sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./scene/2.2.1-solo-retro-go-$consola.sh
+	sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./scene/2.2.1-save-state-$consola.sh
     sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./scene/2.2.2-cfw-retro-go-1mb-$consola.sh
+	sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./scene/2.2.2-save-state-$consola.sh
     sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./scene/2.2.3-cfw-retro-go-16mb-$consola.sh
+	sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./scene/2.2.3-save-state-$consola.sh
     sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./scene/2.2.4-cfw-retro-go-64mb-$consola.sh
+	sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./scene/2.2.4-save-state-$consola.sh
     ./scene/2.2-retro-go-$consola.sh
     ./2-menu-scene-$consola.sh
     clear;;

--- a/2-menu-scene-mario.sh
+++ b/2-menu-scene-mario.sh
@@ -25,10 +25,10 @@ case $menuitem in
     sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./scene/2.2.2-cfw-retro-go-1mb-$consola.sh
     sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./scene/2.2.3-cfw-retro-go-16mb-$consola.sh
     sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./scene/2.2.4-cfw-retro-go-64mb-$consola.sh
-    sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./2.2.1-save-state-$consola.sh
-    sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./2.2.2-save-state-$consola.sh
-    sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./2.2.3-save-state-$consola.sh
-    sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./2.2.4-save-state-$consola.sh
+    sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./scene/2.2.1-save-state-$consola.sh
+    sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./scene/2.2.2-save-state-$consola.sh
+    sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./scene/2.2.3-save-state-$consola.sh
+    sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./scene/2.2.4-save-state-$consola.sh
     ./scene/2.2-retro-go-$consola.sh
     ./2-menu-scene-$consola.sh
     clear;;

--- a/2-menu-scene-mario.sh
+++ b/2-menu-scene-mario.sh
@@ -9,7 +9,11 @@ dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO
 --title "Game&Watch $consola - menu de flasheo" \
 --ok-label Apply \
 --cancel-label Exit \
---menu "Selecciona con las flechas la opcion deseada:" 10 120 15 \
+--menu "
+Usuario actual: $usuario
+Consola seleccionada: $consola
+
+Selecciona con las flechas la opcion deseada:" 0 0 0 \
    1 "Backup, restauracion y liberacion de la G&W $consola" \
    2 "Instalacion Custom FirmWare (CFW) y RetroGo y backup/restauracion de save states en G&W $consola" \
    3 "Generación roms Game&Watch" 2>"${INPUT}"

--- a/2-menu-scene-zelda.sh
+++ b/2-menu-scene-zelda.sh
@@ -11,7 +11,7 @@ dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO
 --cancel-label Exit \
 --menu "Selecciona con las flechas la opcion deseada:" 10 120 15 \
    1 "Backup, restauracion y liberacion de la G&W $consola" \
-   2 "Instalacion Custom FirmWare (CFW) y RetroGo en G&W $consola" \
+   2 "Instalacion Custom FirmWare (CFW) y RetroGo y backup/restauracion de save states en G&W $consola" \
    3 "Generación roms Game&Watch" 2>"${INPUT}"
 menuitem=$(<"${INPUT}")
 case $menuitem in
@@ -25,6 +25,10 @@ case $menuitem in
     sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./scene/2.2.2-cfw-retro-go-1mb-$consola.sh
     sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./scene/2.2.3-cfw-retro-go-16mb-$consola.sh
     sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./scene/2.2.4-cfw-retro-go-64mb-$consola.sh
+    sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./2.2.1-save-state-$consola.sh
+    sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./2.2.2-save-state-$consola.sh
+    sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./2.2.3-save-state-$consola.sh
+    sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./2.2.4-save-state-$consola.sh
     ./scene/2.2-retro-go-$consola.sh
     ./2-menu-scene-$consola.sh
     clear;;

--- a/2-menu-scene-zelda.sh
+++ b/2-menu-scene-zelda.sh
@@ -22,9 +22,13 @@ case $menuitem in
   2)clear
     sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./scene/2.2-retro-go-$consola.sh
     sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./scene/2.2.1-solo-retro-go-$consola.sh
-    sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./scene/2.2.2-cfw-retro-go-1mb-$consola.sh
+	sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./scene/2.2.1-save-state-$consola.sh
+    sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./scene/2.2.2-cfw-retro-go-4mb-$consola.sh
+	sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./scene/2.2.2-save-state-$consola.sh
     sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./scene/2.2.3-cfw-retro-go-16mb-$consola.sh
+	sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./scene/2.2.3-save-state-$consola.sh
     sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./scene/2.2.4-cfw-retro-go-64mb-$consola.sh
+	sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./scene/2.2.4-save-state-$consola.sh
     ./scene/2.2-retro-go-$consola.sh
     ./2-menu-scene-$consola.sh
     clear;;

--- a/2-menu-scene-zelda.sh
+++ b/2-menu-scene-zelda.sh
@@ -22,13 +22,9 @@ case $menuitem in
   2)clear
     sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./scene/2.2-retro-go-$consola.sh
     sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./scene/2.2.1-solo-retro-go-$consola.sh
-	sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./scene/2.2.1-save-state-$consola.sh
-    sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./scene/2.2.2-cfw-retro-go-4mb-$consola.sh
-	sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./scene/2.2.2-save-state-$consola.sh
+    sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./scene/2.2.2-cfw-retro-go-1mb-$consola.sh
     sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./scene/2.2.3-cfw-retro-go-16mb-$consola.sh
-	sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./scene/2.2.3-save-state-$consola.sh
     sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./scene/2.2.4-cfw-retro-go-64mb-$consola.sh
-	sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./scene/2.2.4-save-state-$consola.sh
     ./scene/2.2-retro-go-$consola.sh
     ./2-menu-scene-$consola.sh
     clear;;

--- a/2-menu-scene-zelda.sh
+++ b/2-menu-scene-zelda.sh
@@ -25,10 +25,10 @@ case $menuitem in
     sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./scene/2.2.2-cfw-retro-go-1mb-$consola.sh
     sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./scene/2.2.3-cfw-retro-go-16mb-$consola.sh
     sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./scene/2.2.4-cfw-retro-go-64mb-$consola.sh
-    sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./2.2.1-save-state-$consola.sh
-    sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./2.2.2-save-state-$consola.sh
-    sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./2.2.3-save-state-$consola.sh
-    sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./2.2.4-save-state-$consola.sh
+    sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./scene/2.2.1-save-state-$consola.sh
+    sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./scene/2.2.2-save-state-$consola.sh
+    sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./scene/2.2.3-save-state-$consola.sh
+    sed -i 's/^proc=.*$/'proc=\""$(nproc)"\"'/g' ./scene/2.2.4-save-state-$consola.sh
     ./scene/2.2-retro-go-$consola.sh
     ./2-menu-scene-$consola.sh
     clear;;

--- a/2-menu-scene-zelda.sh
+++ b/2-menu-scene-zelda.sh
@@ -9,7 +9,11 @@ dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO
 --title "Game&Watch $consola - menu de flasheo" \
 --ok-label Apply \
 --cancel-label Exit \
---menu "Selecciona con las flechas la opcion deseada:" 10 120 15 \
+--menu "
+Usuario actual: $usuario
+Consola seleccionada: $consola
+
+Selecciona con las flechas la opcion deseada:" 0 0 0 \
    1 "Backup, restauracion y liberacion de la G&W $consola" \
    2 "Instalacion Custom FirmWare (CFW) y RetroGo y backup/restauracion de save states en G&W $consola" \
    3 "Generación roms Game&Watch" 2>"${INPUT}"

--- a/instalacion/1.1-cambio-usuario.sh
+++ b/instalacion/1.1-cambio-usuario.sh
@@ -27,26 +27,19 @@ if [ "$confirm" = "s" ]; then
     sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2-retro-go-zelda.sh
     sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.1-solo-retro-go-mario.sh
     sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.1-solo-retro-go-zelda.sh
-	sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.1-save-state-mario.sh
-	sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.1-save-state-zelda.sh
     sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.2-cfw-retro-go-1mb-mario.sh
     sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.2-cfw-retro-go-4mb-zelda.sh
-	sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.2-save-state-mario.sh
-	sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.2-save-state-zelda.sh
     sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.3-cfw-retro-go-16mb-mario.sh
     sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.3-cfw-retro-go-16mb-zelda.sh
-	sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.3-save-state-mario.sh
-	sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.3-save-state-zelda.sh
     sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.4-cfw-retro-go-64mb-mario.sh
     sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.4-cfw-retro-go-64mb-zelda.sh
-	sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.4-save-state-mario.sh
-	sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.4-save-state-zelda.sh
     sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.5-actualizacion-retro-go.sh
     sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.6-actualizacion-parche.sh
     sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./menu.sh
     #sleep 3
 else
-    if [ "$confirm" = "S" ]; then
+    if [ "$confirm" = "S" ]
+    then
         confirm="S"
         sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./instalacion/1.3-preparacion-sistema.sh
         sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./instalacion/1.4-openocd.sh
@@ -63,25 +56,17 @@ else
         sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2-retro-go-zelda.sh
         sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.1-solo-retro-go-mario.sh
         sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.1-solo-retro-go-zelda.sh
-	    sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.1-save-state-mario.sh
-	    sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.1-save-state-zelda.sh
         sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.2-cfw-retro-go-1mb-mario.sh
         sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.2-cfw-retro-go-4mb-zelda.sh
-	    sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.2-save-state-mario.sh
-	    sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.2-save-state-zelda.sh
         sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.3-cfw-retro-go-16mb-mario.sh
         sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.3-cfw-retro-go-16mb-zelda.sh
-	    sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.3-save-state-mario.sh
-	    sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.3-save-state-zelda.sh
         sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.4-cfw-retro-go-64mb-mario.sh
         sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.4-cfw-retro-go-64mb-zelda.sh
-	    sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.4-save-state-mario.sh
-	    sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.4-save-state-zelda.sh
         sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.5-actualizacion-retro-go.sh
         sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.6-actualizacion-parche.sh
         sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./menu.sh
         #sleep 3
-   fi
+    fi
 fi
 
 if [ "$confirm" != "S" ]

--- a/instalacion/1.1-cambio-usuario.sh
+++ b/instalacion/1.1-cambio-usuario.sh
@@ -27,19 +27,26 @@ if [ "$confirm" = "s" ]; then
     sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2-retro-go-zelda.sh
     sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.1-solo-retro-go-mario.sh
     sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.1-solo-retro-go-zelda.sh
+	sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.1-save-state-mario.sh
+	sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.1-save-state-zelda.sh
     sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.2-cfw-retro-go-1mb-mario.sh
     sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.2-cfw-retro-go-4mb-zelda.sh
+	sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.2-save-state-mario.sh
+	sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.2-save-state-zelda.sh
     sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.3-cfw-retro-go-16mb-mario.sh
     sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.3-cfw-retro-go-16mb-zelda.sh
+	sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.3-save-state-mario.sh
+	sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.3-save-state-zelda.sh
     sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.4-cfw-retro-go-64mb-mario.sh
     sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.4-cfw-retro-go-64mb-zelda.sh
+	sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.4-save-state-mario.sh
+	sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.4-save-state-zelda.sh
     sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.5-actualizacion-retro-go.sh
     sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.6-actualizacion-parche.sh
     sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./menu.sh
     #sleep 3
 else
-    if [ "$confirm" = "S" ]
-    then
+    if [ "$confirm" = "S" ]; then
         confirm="S"
         sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./instalacion/1.3-preparacion-sistema.sh
         sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./instalacion/1.4-openocd.sh
@@ -56,17 +63,25 @@ else
         sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2-retro-go-zelda.sh
         sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.1-solo-retro-go-mario.sh
         sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.1-solo-retro-go-zelda.sh
+	    sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.1-save-state-mario.sh
+	    sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.1-save-state-zelda.sh
         sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.2-cfw-retro-go-1mb-mario.sh
         sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.2-cfw-retro-go-4mb-zelda.sh
+	    sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.2-save-state-mario.sh
+	    sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.2-save-state-zelda.sh
         sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.3-cfw-retro-go-16mb-mario.sh
         sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.3-cfw-retro-go-16mb-zelda.sh
+	    sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.3-save-state-mario.sh
+	    sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.3-save-state-zelda.sh
         sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.4-cfw-retro-go-64mb-mario.sh
         sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.4-cfw-retro-go-64mb-zelda.sh
+	    sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.4-save-state-mario.sh
+	    sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.4-save-state-zelda.sh
         sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.5-actualizacion-retro-go.sh
         sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.6-actualizacion-parche.sh
         sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./menu.sh
         #sleep 3
-    fi
+   fi
 fi
 
 if [ "$confirm" != "S" ]

--- a/instalacion/1.1-cambio-usuario.sh
+++ b/instalacion/1.1-cambio-usuario.sh
@@ -35,6 +35,8 @@ if [ "$confirm" = "s" ]; then
     sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.4-cfw-retro-go-64mb-zelda.sh
     sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.5-actualizacion-retro-go.sh
     sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.6-actualizacion-parche.sh
+    sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.C-opcion-caratula.sh
+    sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.H-opcion-herramientas.sh
     sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./menu.sh
     #sleep 3
 else
@@ -64,6 +66,8 @@ else
         sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.4-cfw-retro-go-64mb-zelda.sh
         sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.5-actualizacion-retro-go.sh
         sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.6-actualizacion-parche.sh
+        sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.C-opcion-caratula.sh
+        sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./scene/2.2.H-opcion-herramientas.sh
         sed -i 's/^usuario=.*$/'usuario=\""$varname"\"'/g' ./menu.sh
         #sleep 3
     fi

--- a/instalacion/1.2-cambio-consola.sh
+++ b/instalacion/1.2-cambio-consola.sh
@@ -18,9 +18,13 @@ case $menuitem in
     sed -i 's/^consola=.*$/'consola=\""mario"\"'/g' ./scene/2.1-backup-restauracion.sh
     sed -i 's/^consola=.*$/'consola=\""mario"\"'/g' ./scene/2.2-retro-go-mario.sh
     sed -i 's/^consola=.*$/'consola=\""mario"\"'/g' ./scene/2.2.1-solo-retro-go-mario.sh
+	sed -i 's/^consola=.*$/'consola=\""mario"\"'/g' ./scene/2.2.1-save-state-mario.sh
     sed -i 's/^consola=.*$/'consola=\""mario"\"'/g' ./scene/2.2.2-cfw-retro-go-1mb-mario.sh
+	sed -i 's/^consola=.*$/'consola=\""mario"\"'/g' ./scene/2.2.2-save-state-mario.sh
     sed -i 's/^consola=.*$/'consola=\""mario"\"'/g' ./scene/2.2.3-cfw-retro-go-16mb-mario.sh
+	sed -i 's/^consola=.*$/'consola=\""mario"\"'/g' ./scene/2.2.3-save-state-mario.sh
     sed -i 's/^consola=.*$/'consola=\""mario"\"'/g' ./scene/2.2.4-cfw-retro-go-64mb-mario.sh
+	sed -i 's/^consola=.*$/'consola=\""mario"\"'/g' ./scene/2.2.4-save-state-mario.sh
 	sed -i 's/^consola=.*$/'consola=\""mario"\"'/g' ./menu.sh
     echo "Opcion mario aplicada"
     sleep 2
@@ -31,9 +35,13 @@ case $menuitem in
     sed -i 's/^consola=.*$/'consola=\""zelda"\"'/g' ./scene/2.1-backup-restauracion.sh
     sed -i 's/^consola=.*$/'consola=\""zelda"\"'/g' ./scene/2.2-retro-go-zelda.sh
     sed -i 's/^consola=.*$/'consola=\""zelda"\"'/g' ./scene/2.2.1-solo-retro-go-zelda.sh
+	sed -i 's/^consola=.*$/'consola=\""zelda"\"'/g' ./scene/2.2.1-save-state-zelda.sh
     sed -i 's/^consola=.*$/'consola=\""zelda"\"'/g' ./scene/2.2.2-cfw-retro-go-4mb-zelda.sh
+	sed -i 's/^consola=.*$/'consola=\""zelda"\"'/g' ./scene/2.2.2-save-state-zelda.sh
     sed -i 's/^consola=.*$/'consola=\""zelda"\"'/g' ./scene/2.2.3-cfw-retro-go-16mb-zelda.sh
+	sed -i 's/^consola=.*$/'consola=\""zelda"\"'/g' ./scene/2.2.3-save-state-zelda.sh
     sed -i 's/^consola=.*$/'consola=\""zelda"\"'/g' ./scene/2.2.4-cfw-retro-go-64mb-zelda.sh
+	sed -i 's/^consola=.*$/'consola=\""zelda"\"'/g' ./scene/2.2.4-save-state-zelda.sh
     sed -i 's/^consola=.*$/'consola=\""zelda"\"'/g' ./menu.sh
     echo "Opcion zelda aplicada"
     sleep 2

--- a/instalacion/1.2-cambio-consola.sh
+++ b/instalacion/1.2-cambio-consola.sh
@@ -18,13 +18,9 @@ case $menuitem in
     sed -i 's/^consola=.*$/'consola=\""mario"\"'/g' ./scene/2.1-backup-restauracion.sh
     sed -i 's/^consola=.*$/'consola=\""mario"\"'/g' ./scene/2.2-retro-go-mario.sh
     sed -i 's/^consola=.*$/'consola=\""mario"\"'/g' ./scene/2.2.1-solo-retro-go-mario.sh
-	sed -i 's/^consola=.*$/'consola=\""mario"\"'/g' ./scene/2.2.1-save-state-mario.sh
     sed -i 's/^consola=.*$/'consola=\""mario"\"'/g' ./scene/2.2.2-cfw-retro-go-1mb-mario.sh
-	sed -i 's/^consola=.*$/'consola=\""mario"\"'/g' ./scene/2.2.2-save-state-mario.sh
     sed -i 's/^consola=.*$/'consola=\""mario"\"'/g' ./scene/2.2.3-cfw-retro-go-16mb-mario.sh
-	sed -i 's/^consola=.*$/'consola=\""mario"\"'/g' ./scene/2.2.3-save-state-mario.sh
     sed -i 's/^consola=.*$/'consola=\""mario"\"'/g' ./scene/2.2.4-cfw-retro-go-64mb-mario.sh
-	sed -i 's/^consola=.*$/'consola=\""mario"\"'/g' ./scene/2.2.4-save-state-mario.sh
 	sed -i 's/^consola=.*$/'consola=\""mario"\"'/g' ./menu.sh
     echo "Opcion mario aplicada"
     sleep 2
@@ -35,13 +31,9 @@ case $menuitem in
     sed -i 's/^consola=.*$/'consola=\""zelda"\"'/g' ./scene/2.1-backup-restauracion.sh
     sed -i 's/^consola=.*$/'consola=\""zelda"\"'/g' ./scene/2.2-retro-go-zelda.sh
     sed -i 's/^consola=.*$/'consola=\""zelda"\"'/g' ./scene/2.2.1-solo-retro-go-zelda.sh
-	sed -i 's/^consola=.*$/'consola=\""zelda"\"'/g' ./scene/2.2.1-save-state-zelda.sh
     sed -i 's/^consola=.*$/'consola=\""zelda"\"'/g' ./scene/2.2.2-cfw-retro-go-4mb-zelda.sh
-	sed -i 's/^consola=.*$/'consola=\""zelda"\"'/g' ./scene/2.2.2-save-state-zelda.sh
     sed -i 's/^consola=.*$/'consola=\""zelda"\"'/g' ./scene/2.2.3-cfw-retro-go-16mb-zelda.sh
-	sed -i 's/^consola=.*$/'consola=\""zelda"\"'/g' ./scene/2.2.3-save-state-zelda.sh
     sed -i 's/^consola=.*$/'consola=\""zelda"\"'/g' ./scene/2.2.4-cfw-retro-go-64mb-zelda.sh
-	sed -i 's/^consola=.*$/'consola=\""zelda"\"'/g' ./scene/2.2.4-save-state-zelda.sh
     sed -i 's/^consola=.*$/'consola=\""zelda"\"'/g' ./menu.sh
     echo "Opcion zelda aplicada"
     sleep 2

--- a/instalacion/1.2-cambio-consola.sh
+++ b/instalacion/1.2-cambio-consola.sh
@@ -21,6 +21,7 @@ case $menuitem in
     sed -i 's/^consola=.*$/'consola=\""mario"\"'/g' ./scene/2.2.2-cfw-retro-go-1mb-mario.sh
     sed -i 's/^consola=.*$/'consola=\""mario"\"'/g' ./scene/2.2.3-cfw-retro-go-16mb-mario.sh
     sed -i 's/^consola=.*$/'consola=\""mario"\"'/g' ./scene/2.2.4-cfw-retro-go-64mb-mario.sh
+    sed -i 's/^consola=.*$/'consola=\""mario"\"'/g' ./scene/2.2.H-opcion-herramientas.sh
 	sed -i 's/^consola=.*$/'consola=\""mario"\"'/g' ./menu.sh
     echo "Opcion mario aplicada"
     sleep 2
@@ -34,6 +35,7 @@ case $menuitem in
     sed -i 's/^consola=.*$/'consola=\""zelda"\"'/g' ./scene/2.2.2-cfw-retro-go-4mb-zelda.sh
     sed -i 's/^consola=.*$/'consola=\""zelda"\"'/g' ./scene/2.2.3-cfw-retro-go-16mb-zelda.sh
     sed -i 's/^consola=.*$/'consola=\""zelda"\"'/g' ./scene/2.2.4-cfw-retro-go-64mb-zelda.sh
+    sed -i 's/^consola=.*$/'consola=\""zelda"\"'/g' ./scene/2.2.H-opcion-herramientas.sh
     sed -i 's/^consola=.*$/'consola=\""zelda"\"'/g' ./menu.sh
     echo "Opcion zelda aplicada"
     sleep 2

--- a/instalacion/1.3-preparacion-sistema.sh
+++ b/instalacion/1.3-preparacion-sistema.sh
@@ -18,7 +18,7 @@ clear
 #fi
 sudo apt update -y
 sudo apt upgrade -y
-sudo apt install -y binutils-arm-none-eabi python3 libhidapi-hidraw0 libftdi1 libftdi1-2 git python3-pip
+sudo apt install -y unzip binutils-arm-none-eabi python3 libhidapi-hidraw0 libftdi1 libftdi1-2 git python3-pip
 clear
 #cd /home/$usuario
 #if [ -d /home/$usuario/gameandwatch ]; then

--- a/libncurses5.txt
+++ b/libncurses5.txt
@@ -1,0 +1,20 @@
+Package: libncurses5
+Status: install ok installed
+Priority: optional
+Section: oldlibs
+Installed-Size: 318
+Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
+Architecture: amd64
+Multi-Arch: same
+Source: ncurses
+Version: 6.3-2
+Depends: libtinfo5 (= 6.3-2), libc6 (>= 2.34)
+Recommends: libgpm2
+Description: shared libraries for terminal handling (legacy version)
+ The ncurses library routines are a terminal-independent method of
+ updating character screens with reasonable optimization.
+ .
+ This package contains the legacy shared libraries necessary to run
+ programs compiled with ncurses.
+Original-Maintainer: Craig Small <csmall@debian.org>
+Homepage: https://invisible-island.net/ncurses/

--- a/menu.sh
+++ b/menu.sh
@@ -3,7 +3,7 @@
 
 INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
-consola="mario"
+consola="zelda"
 
 clear
 which dialog > dialog.txt

--- a/menu.sh
+++ b/menu.sh
@@ -3,7 +3,7 @@
 
 INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
-consola="mario"
+consola="zelda"
 
 clear
 which dialog > dialog.txt
@@ -23,9 +23,11 @@ dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO
 --title "Game&Watch - Menu ayuda para el flasheo" \
 --ok-label Apply \
 --cancel-label Exit \
---menu "Selecciona con las flechas la opcion deseada:
+--menu "
 Usuario actual: $usuario
-Consola seleccionada: $consola" 0 0 0 \
+Consola seleccionada: $consola
+
+Selecciona con las flechas la opcion deseada:" 0 0 0 \
    1 "Cambio de usuario. IMPORTANTE: la primera vez es esencial ejecutar esto para el correcto funcionamiento" \
    2 "Cambio de modelo de consola (actual = $consola). IMPORTANTE: Escoge el modelo correcto para el correcto funcionamiento" \
    3 "Menu instalacion paquetes y programas necesarios y actualizacion del firm del STLINK" \

--- a/menu.sh
+++ b/menu.sh
@@ -3,7 +3,7 @@
 
 INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
-consola="mario"
+consola="zelda"
 
 clear
 which dialog > dialog.txt
@@ -23,7 +23,9 @@ dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO
 --title "Game&Watch - Menu ayuda para el flasheo" \
 --ok-label Apply \
 --cancel-label Exit \
---menu "Selecciona con las flechas la opcion deseada:" 12 125 15 \
+--menu "Selecciona con las flechas la opcion deseada:
+Usuario actual: $usuario
+Consola seleccionada: $consola" 0 0 0 \
    1 "Cambio de usuario. IMPORTANTE: la primera vez es esencial ejecutar esto para el correcto funcionamiento" \
    2 "Cambio de modelo de consola (actual = $consola). IMPORTANTE: Escoge el modelo correcto para el correcto funcionamiento" \
    3 "Menu instalacion paquetes y programas necesarios y actualizacion del firm del STLINK" \

--- a/menu.sh
+++ b/menu.sh
@@ -3,7 +3,7 @@
 
 INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
-consola="zelda"
+consola="mario"
 
 clear
 which dialog > dialog.txt

--- a/menu.sh
+++ b/menu.sh
@@ -27,7 +27,7 @@ dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO
    1 "Cambio de usuario. IMPORTANTE: la primera vez es esencial ejecutar esto para el correcto funcionamiento" \
    2 "Cambio de modelo de consola (actual = $consola). IMPORTANTE: Escoge el modelo correcto para el correcto funcionamiento" \
    3 "Menu instalacion paquetes y programas necesarios y actualizacion del firm del STLINK" \
-   4 "Menu scene: backup/restauracion/liberacion y flasheo custom firm con Retro-Go" \
+   4 "Menu scene: backup/restauracion/liberacion,flasheo custom firm con Retro-Go y backup/restauracion save states" \
    5 "Actualizar el repo local de estos scripts" 2>"${INPUT}"
 menuitem=$(<"${INPUT}")
 case $menuitem in

--- a/scene/2.1-backup-restauracion.sh
+++ b/scene/2.1-backup-restauracion.sh
@@ -3,7 +3,7 @@
 
 INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
-consola="mario"
+consola="zelda"
 
 dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.1-backup-restauracion.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
 --title "G&W menu backup/restauracion/liberacion" \

--- a/scene/2.1-backup-restauracion.sh
+++ b/scene/2.1-backup-restauracion.sh
@@ -3,7 +3,7 @@
 
 INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
-consola="mario"
+consola="zelda"
 
 dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.1-backup-restauracion.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
 --title "G&W menu backup/restauracion/liberacion" \
@@ -12,7 +12,10 @@ dialog --backtitle "G&W $consola - Utilidades de flasheo" \
 --title "G&W menu backup/restauracion/liberacion" \
 --ok-label Apply \
 --cancel-label Exit \
---menu "Selecciona con las flechas la opcion deseada:" 14 150 15 \
+--menu "
+Consola seleccionada: $consola
+
+Selecciona con las flechas la opcion deseada:" 0 0 0 \
    1 "Sanity check: comprobacion de dependencias y elementos necesarios." \
    2 "Backup flash externa: realiza un backup de la flash SPI. No modifica el contenido." \
    3 "Backup de la flash interna: ATENCION: se modifica el contenido de la flash SPI del punto anterior. Puede tardar hasta 5 min" \

--- a/scene/2.1-backup-restauracion.sh
+++ b/scene/2.1-backup-restauracion.sh
@@ -3,7 +3,7 @@
 
 INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
-consola="zelda"
+consola="mario"
 
 dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.1-backup-restauracion.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
 --title "G&W menu backup/restauracion/liberacion" \

--- a/scene/2.2-retro-go-mario.sh
+++ b/scene/2.2-retro-go-mario.sh
@@ -20,6 +20,7 @@ Consola seleccionada: $consola
 Opcion caratulas: $caratula (0=NO y 1=SI)
 
 Selecciona con las flechas la opcion deseada:" 0 0 0 \
+   C "Opcion flasheo con caratula. Actualmente:$caratula (0=NO y 1=SI)" \
    1 "1MB, 16MB y 64MB sin CFW: Menu flasheo solo Retro-Go + backup/restauracion save states en consola G&W $consola" \
    2 "1MB: Menu CFW + Retro-Go + backup/restauracion save states en consola G&W $consola original" \
    3 "16MB: Menu CFW + Retro-Go + backup/restauracion save states en consola G&W $consola" \

--- a/scene/2.2-retro-go-mario.sh
+++ b/scene/2.2-retro-go-mario.sh
@@ -5,7 +5,7 @@ INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="mario"
 proc="4"
-caratula="1"
+caratula="0"
 
 dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2-retro-go-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
 --title "G&W $consola menu Retro-Go + custom firmware" \

--- a/scene/2.2-retro-go-mario.sh
+++ b/scene/2.2-retro-go-mario.sh
@@ -4,7 +4,7 @@
 INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="mario"
-proc="6"
+proc="4"
 caratula="0"
 
 dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2-retro-go-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
@@ -20,6 +20,7 @@ Consola seleccionada: $consola
 Opcion caratulas: $caratula (0=NO y 1=SI)
 
 Selecciona con las flechas la opcion deseada:" 0 0 0 \
+   H "Herramientas y utilidades" \
    C "Opcion flasheo con caratula. Actualmente:$caratula (0=NO y 1=SI)" \
    1 "1MB, 16MB y 64MB sin CFW: Menu flasheo solo Retro-Go + backup/restauracion save states en consola G&W $consola" \
    2 "1MB: Menu CFW + Retro-Go + backup/restauracion save states en consola G&W $consola original" \
@@ -31,6 +32,10 @@ menuitem=$(<"${INPUT}")
 case $menuitem in
   C)clear
     ./scene/2.2.C-opcion-caratula.sh
+    ./scene/2.2-retro-go-$consola.sh
+    clear;;
+  H)clear
+    ./scene/2.2.H-opcion-herramientas.sh
     ./scene/2.2-retro-go-$consola.sh
     clear;;
   1)clear

--- a/scene/2.2-retro-go-mario.sh
+++ b/scene/2.2-retro-go-mario.sh
@@ -4,7 +4,7 @@
 INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="mario"
-proc="4"
+proc="6"
 caratula="0"
 
 dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2-retro-go-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
@@ -14,12 +14,16 @@ dialog --backtitle "G&W $consola - Utilidades de flasheo ------- INFO: 2.2-retro
 --title "G&W $consola CFW + Retro-Go /// INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Roms en /home/$usuario/game-and-watch-retro-go/roms/" \
 --ok-label Apply \
 --cancel-label Exit \
---menu "Selecciona con las flechas la opcion deseada:" 14 140 15 \
-   C "Opcion flasheo con caratula. Actualmente:$caratula (0=NO y 1=SI)" \
-   1 "Subir solo Retro-Go + backup/restauracion save states en consola G&W $consola sin CFW " \
-   2 "Menu CFW + Retro-Go + backup/restauracion save states en consola G&W $consola original 1MB " \
-   3 "Menu CFW + Retro-Go + backup/restauracion save states en consola G&W $consola con 16MB " \
-   4 "Menu CFW + Retro-Go + backup/restauracion save states en consola G&W $consola con 64MB " \
+--menu "
+Usuario actual: $usuario
+Consola seleccionada: $consola
+Opcion caratulas: $caratula (0=NO y 1=SI)
+
+Selecciona con las flechas la opcion deseada:" 0 0 0 \
+   1 "1MB, 16MB y 64MB sin CFW: Menu flasheo solo Retro-Go + backup/restauracion save states en consola G&W $consola" \
+   2 "1MB: Menu CFW + Retro-Go + backup/restauracion save states en consola G&W $consola original" \
+   3 "16MB: Menu CFW + Retro-Go + backup/restauracion save states en consola G&W $consola" \
+   4 "64MB: Menu CFW + Retro-Go + backup/restauracion save states en consola G&W $consola" \
    5 "Actualizacion del directorio del repo local de Retro-Go" \
    6 "Actualizacion del directorio del parche para el CFW"   2>"${INPUT}"
 menuitem=$(<"${INPUT}")

--- a/scene/2.2-retro-go-mario.sh
+++ b/scene/2.2-retro-go-mario.sh
@@ -20,7 +20,6 @@ Consola seleccionada: $consola
 Opcion caratulas: $caratula (0=NO y 1=SI)
 
 Selecciona con las flechas la opcion deseada:" 0 0 0 \
-   H "Herramientas y utilidades" \
    C "Opcion flasheo con caratula. Actualmente:$caratula (0=NO y 1=SI)" \
    1 "1MB, 16MB y 64MB sin CFW: Menu flasheo solo Retro-Go + backup/restauracion save states en consola G&W $consola" \
    2 "1MB: Menu CFW + Retro-Go + backup/restauracion save states en consola G&W $consola original" \
@@ -32,10 +31,6 @@ menuitem=$(<"${INPUT}")
 case $menuitem in
   C)clear
     ./scene/2.2.C-opcion-caratula.sh
-    ./scene/2.2-retro-go-$consola.sh
-    clear;;
-  H)clear
-    ./scene/2.2.H-opcion-herramientas.sh
     ./scene/2.2-retro-go-$consola.sh
     clear;;
   1)clear

--- a/scene/2.2-retro-go-mario.sh
+++ b/scene/2.2-retro-go-mario.sh
@@ -16,10 +16,10 @@ dialog --backtitle "G&W $consola - Utilidades de flasheo ------- INFO: 2.2-retro
 --cancel-label Exit \
 --menu "Selecciona con las flechas la opcion deseada:" 14 140 15 \
    C "Opcion flasheo con caratula. Actualmente:$caratula (0=NO y 1=SI)" \
-   1 "Subir solo Retro-Go en consola G&W $consola sin CFW" \
-   2 "Menu CFW + Retro-Go en consola G&W $consola original 1MB" \
-   3 "Menu CFW + Retro-Go en consola G&W $consola con 16MB" \
-   4 "Menu CFW + Retro-Go en consola G&W $consola con 64MB" \
+   1 "Subir solo Retro-Go + backup/restauracion save states en consola G&W $consola sin CFW " \
+   2 "Menu CFW + Retro-Go + backup/restauracion save states en consola G&W $consola original 1MB " \
+   3 "Menu CFW + Retro-Go + backup/restauracion save states en consola G&W $consola con 16MB " \
+   4 "Menu CFW + Retro-Go + backup/restauracion save states en consola G&W $consola con 64MB " \
    5 "Actualizacion del directorio del repo local de Retro-Go" \
    6 "Actualizacion del directorio del parche para el CFW"   2>"${INPUT}"
 menuitem=$(<"${INPUT}")

--- a/scene/2.2-retro-go-mario.sh
+++ b/scene/2.2-retro-go-mario.sh
@@ -5,7 +5,7 @@ INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="mario"
 proc="4"
-caratula="0"
+caratula="1"
 
 dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2-retro-go-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
 --title "G&W $consola menu Retro-Go + custom firmware" \

--- a/scene/2.2-retro-go-zelda.sh
+++ b/scene/2.2-retro-go-zelda.sh
@@ -5,7 +5,7 @@ INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="zelda"
 proc="4"
-caratula="1"
+caratula="0"
 
 dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2-retro-go-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
 --title "G&W $consola menu Retro-Go + custom firmware" \

--- a/scene/2.2-retro-go-zelda.sh
+++ b/scene/2.2-retro-go-zelda.sh
@@ -4,7 +4,7 @@
 INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="zelda"
-proc="4"
+proc="6"
 caratula="0"
 
 dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2-retro-go-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
@@ -14,12 +14,17 @@ dialog --backtitle "G&W $consola - Utilidades de flasheo ------- INFO: 2.2-retro
 --title "G&W $consola CFW + Retro-Go /// INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Roms en /home/$usuario/game-and-watch-retro-go/roms/" \
 --ok-label Apply \
 --cancel-label Exit \
---menu "Selecciona con las flechas la opcion deseada:" 14 140 15 \
+--menu "
+Usuario actual: $usuario
+Consola seleccionada: $consola
+Opcion caratulas: $caratula (0=NO y 1=SI)
+
+Selecciona con las flechas la opcion deseada:" 0 0 0 \
    C "Opcion flasheo con caratula. Actualmente:$caratula (0=NO y 1=SI)" \
-   1 "Subir solo Retro-Go + backup/restauracion save states en consola G&W $consola sin CFW " \
-   2 "Menu CFW + Retro-Go + backup/restauracion save states en consola G&W $consola original 4MB " \
-   3 "Menu CFW + Retro-Go + backup/restauracion save states en consola G&W $consola con 16MB " \
-   4 "Menu CFW + Retro-Go + backup/restauracion save states en consola G&W $consola con 64MB " \
+   1 "4MB, 16MB y 64MB sin CFW: Menu flasheo solo Retro-Go + backup/restauracion save states en consola G&W $consola" \
+   2 "4MB: Menu CFW + Retro-Go + backup/restauracion save states en consola G&W $consola original" \
+   3 "16MB: Menu CFW + Retro-Go + backup/restauracion save states en consola G&W $consola" \
+   4 "64MB: Menu CFW + Retro-Go + backup/restauracion save states en consola G&W $consola" \
    5 "Actualizacion del directorio del repo local de Retro-Go" \
    6 "Actualizacion del directorio del parche para el CFW"   2>"${INPUT}"
 menuitem=$(<"${INPUT}")

--- a/scene/2.2-retro-go-zelda.sh
+++ b/scene/2.2-retro-go-zelda.sh
@@ -5,7 +5,7 @@ INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="zelda"
 proc="4"
-caratula="0"
+caratula="1"
 
 dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2-retro-go-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
 --title "G&W $consola menu Retro-Go + custom firmware" \

--- a/scene/2.2-retro-go-zelda.sh
+++ b/scene/2.2-retro-go-zelda.sh
@@ -16,10 +16,10 @@ dialog --backtitle "G&W $consola - Utilidades de flasheo ------- INFO: 2.2-retro
 --cancel-label Exit \
 --menu "Selecciona con las flechas la opcion deseada:" 14 140 15 \
    C "Opcion flasheo con caratula. Actualmente:$caratula (0=NO y 1=SI)" \
-   1 "Subir solo Retro-Go en consola G&W $consola sin CFW" \
-   2 "Menu CFW + Retro-Go en consola G&W $consola original 4MB" \
-   3 "Menu CFW + Retro-Go en consola G&W $consola con 16MB" \
-   4 "Menu CFW + Retro-Go en consola G&W $consola con 64MB" \
+   1 "Subir solo Retro-Go + backup/restauracion save states en consola G&W $consola sin CFW " \
+   2 "Menu CFW + Retro-Go + backup/restauracion save states en consola G&W $consola original 4MB " \
+   3 "Menu CFW + Retro-Go + backup/restauracion save states en consola G&W $consola con 16MB " \
+   4 "Menu CFW + Retro-Go + backup/restauracion save states en consola G&W $consola con 64MB " \
    5 "Actualizacion del directorio del repo local de Retro-Go" \
    6 "Actualizacion del directorio del parche para el CFW"   2>"${INPUT}"
 menuitem=$(<"${INPUT}")

--- a/scene/2.2-retro-go-zelda.sh
+++ b/scene/2.2-retro-go-zelda.sh
@@ -4,7 +4,7 @@
 INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="zelda"
-proc="6"
+proc="4"
 caratula="0"
 
 dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2-retro-go-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
@@ -20,7 +20,6 @@ Consola seleccionada: $consola
 Opcion caratulas: $caratula (0=NO y 1=SI)
 
 Selecciona con las flechas la opcion deseada:" 0 0 0 \
-   H "Herramientas y utilidades" \
    C "Opcion flasheo con caratula. Actualmente:$caratula (0=NO y 1=SI)" \
    1 "4MB, 16MB y 64MB sin CFW: Menu flasheo solo Retro-Go + backup/restauracion save states en consola G&W $consola" \
    2 "4MB: Menu CFW + Retro-Go + backup/restauracion save states en consola G&W $consola original" \
@@ -33,10 +32,6 @@ menuitem=$(<"${INPUT}")
 case $menuitem in
   C)clear
     ./scene/2.2.C-opcion-caratula.sh
-    ./scene/2.2-retro-go-$consola.sh
-    clear;;
-  H)clear
-    ./scene/2.2.H-opcion-herramientas.sh
     ./scene/2.2-retro-go-$consola.sh
     clear;;
   1)clear

--- a/scene/2.2-retro-go-zelda.sh
+++ b/scene/2.2-retro-go-zelda.sh
@@ -26,8 +26,7 @@ Selecciona con las flechas la opcion deseada:" 0 0 0 \
    3 "16MB: Menu CFW + Retro-Go + backup/restauracion save states en consola G&W $consola" \
    4 "64MB: Menu CFW + Retro-Go + backup/restauracion save states en consola G&W $consola" \
    5 "Actualizacion del directorio del repo local de Retro-Go" \
-   6 "Actualizacion del directorio del parche para el CFW" \
-   H "Herramientas y utilidades"   2>"${INPUT}"
+   6 "Actualizacion del directorio del parche para el CFW"   2>"${INPUT}"
 menuitem=$(<"${INPUT}")
 case $menuitem in
   C)clear

--- a/scene/2.2-retro-go-zelda.sh
+++ b/scene/2.2-retro-go-zelda.sh
@@ -20,20 +20,26 @@ Consola seleccionada: $consola
 Opcion caratulas: $caratula (0=NO y 1=SI)
 
 Selecciona con las flechas la opcion deseada:" 0 0 0 \
+   H "Herramientas y utilidades" \
    C "Opcion flasheo con caratula. Actualmente:$caratula (0=NO y 1=SI)" \
    1 "4MB, 16MB y 64MB sin CFW: Menu flasheo solo Retro-Go + backup/restauracion save states en consola G&W $consola" \
    2 "4MB: Menu CFW + Retro-Go + backup/restauracion save states en consola G&W $consola original" \
    3 "16MB: Menu CFW + Retro-Go + backup/restauracion save states en consola G&W $consola" \
    4 "64MB: Menu CFW + Retro-Go + backup/restauracion save states en consola G&W $consola" \
    5 "Actualizacion del directorio del repo local de Retro-Go" \
-   6 "Actualizacion del directorio del parche para el CFW"   2>"${INPUT}"
+   6 "Actualizacion del directorio del parche para el CFW" \
+   H "Herramientas y utilidades"   2>"${INPUT}"
 menuitem=$(<"${INPUT}")
 case $menuitem in
-   C)clear
+  C)clear
     ./scene/2.2.C-opcion-caratula.sh
     ./scene/2.2-retro-go-$consola.sh
     clear;;
- 1)clear
+  H)clear
+    ./scene/2.2.H-opcion-herramientas.sh
+    ./scene/2.2-retro-go-$consola.sh
+    clear;;
+  1)clear
     ./scene/2.2.1-solo-retro-go-$consola.sh
     ./scene/2.2-retro-go-$consola.sh
     clear;;

--- a/scene/2.2.1-save-state-mario.sh
+++ b/scene/2.2.1-save-state-mario.sh
@@ -15,7 +15,7 @@ dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO
 --ok-label Apply \
 --cancel-label Exit \
 --menu "Selecciona con las flechas la opcion deseada:" 14 140 15 \
-   1 "Compilar Retro-Go para consola original sin CFW con 1MB" \
+   1 "prueba" \
    2 "Subir solo Retro-Go sin CFW en consola original con 1MB" \
    3 "Compilar Retro-Go para consola sin CFW con chip de 16MB" \
    4 "Subir solo Retro-Go sin CFW en consola con chip de 16MB" \

--- a/scene/2.2.1-save-state-mario.sh
+++ b/scene/2.2.1-save-state-mario.sh
@@ -4,7 +4,7 @@
 INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="mario"
-proc="4"
+proc="6"
 caratula="0"
 
 clear
@@ -27,7 +27,13 @@ dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO
        --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
        --ok-label Apply \
        --cancel-label Exit \
-       --menu "Selecciona con las flechas la opcion deseada:" 16 140 15 \
+       --menu "
+Usuario actual: $usuario
+Consola seleccionada: $consola
+Opcion caratulas: $caratula (0=NO y 1=SI)
+Save states: /home/$usuario/game-and-watch-retro-go/save_states/
+
+Selecciona con las flechas la opcion deseada:" 0 0 0 \
           1 "1MB $consola solo Retro-Go: Hacer backup de los save states existentes que hay en la G&W" \
           2 "1MB $consola solo Retro-Go: Restaurar los save states desde el pc a la G&W" \
           3 "1MB $consola solo Retro-Go: Borrar los saves states existentes en la G&W para dejarla limpia" \

--- a/scene/2.2.1-save-state-mario.sh
+++ b/scene/2.2.1-save-state-mario.sh
@@ -4,7 +4,7 @@
 INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="mario"
-proc="6"
+proc="4"
 caratula="0"
 
 clear

--- a/scene/2.2.1-save-state-mario.sh
+++ b/scene/2.2.1-save-state-mario.sh
@@ -7,139 +7,262 @@ consola="mario"
 proc="4"
 caratula="1"
 
+clear
+dpkg -s libncurses5 > libncurses5.txt
+if grep "install ok installed" ./libncurses5.txt ; then
+        echo "Encontrado paquete libncurses5, se prosigue..."
+        sleep 0.5
+else
+        echo "No encontrado paquete dialog necesario, instalando..."
+        echo " "
+        sudo apt install -y libncurses5
+        echo " "
+        echo "Instalado!!"
+        sleep 0.5
+fi
+
 dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
---title "G&W $consola CFW + Retro-Go /// INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Roms en /home/$usuario/game-and-watch-retro-go/roms/" \
---ok-label Apply \
---cancel-label Exit \
---menu "Selecciona con las flechas la opcion deseada:" 14 140 15 \
-   1 "prueba" \
-   2 "Subir solo Retro-Go sin CFW en consola original con 1MB" \
-   3 "Compilar Retro-Go para consola sin CFW con chip de 16MB" \
-   4 "Subir solo Retro-Go sin CFW en consola con chip de 16MB" \
-   5 "Compilar Retro-Go para consola sin CFW con chip de 64MB" \
-   6 "Subir solo Retro-Go sin CFW en consola con chip de 64MB"   2>"${INPUT}"
+       --msgbox "G&W Utilidad para backup, resturacion y borrado de save states. Una vez descargados los save states estan ubicados en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" 0 0
+dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+       --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+       --ok-label Apply \
+       --cancel-label Exit \
+       --menu "Selecciona con las flechas la opcion deseada:" 16 140 15 \
+          1 "1MB $consola solo Retro-Go: Hacer backup de los save states existentes que hay en la G&W" \
+          2 "1MB $consola solo Retro-Go: Restaurar los save states desde el pc a la G&W" \
+          3 "1MB $consola solo Retro-Go: Borrar los saves states existentes en la G&W para dejarla limpia" \
+          4 "16MB $consola solo Retro-Go: Hacer backup de los save states existentes que hay en la G&W" \
+          5 "16MB $consola solo Retro-Go: Restaurar los save states desde el pc a la G&W" \
+          6 "16MB $consola solo Retro-Go: Borrar los saves states existentes en la G&W" \
+          7 "64MB $consola solo Retro-Go: Hacer backup de los save states existentes que hay en la G&W" \
+          8 "64MB $consola solo Retro-Go: Restaurar los save states desde el pc a la G&W" \
+          9 "64MB $consola solo Retro-Go: Borrar los saves states existentes en la G&W"   2>"${INPUT}"
 menuitem=$(<"${INPUT}")
 case $menuitem in
   1)clear
-    cd /home/$usuario/gameandwatch/game-and-watch-retro-go
-    make clean
-    make -j$proc COMPRESS=lzma COVERFLOW=$caratula GNW_TARGET=$consola
-    read -n 1 -s -r -p "Presiona cualquier tecla para continuar"
-    cd -
-    ./scene/2.2.1-solo-retro-go-$consola.sh
+    dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+           --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+           --yesno "¡¡¡ATENCION!!! El proceso de BACKUP de los save states puede llegar a tardar varios minutos dependiendo de la cantidad de roms que haya en la G&W y pararlo puede ocasionar errores. ¿Deseas continuar?" 0 0
+    ans=$?
+    if [ $ans -eq 0 ]; then
+        clear
+        echo -e "\e[1;31mEnciende la consola y entra al menu Retro-Go con los botones LEFT+GAME y dejala esperando en el listado de las roms.\e[0m"
+        echo ""
+        echo -e "\e[1;31mPara continuar con el proceso pulsa cualquier tecla...\e[0m"
+        read -n 1 -s -r -p ""
+        cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
+        make -j$proc COMPRESS=lzma COVERFLOW=$caratula GNW_TARGET=$consola flash_saves_backup
+        cd -
+        #sleep 5
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso realizado. Save states descargados en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" 0 0
+    else
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso cancelado." 0 0
+    fi
+    ./scene/2.2.1-save-state-$consola.sh
     clear;;
   2)clear
-    dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-solo-retro-go-mario.sh Usuario = $usuario ------------------" \
-    --title "Instalar solo Retro-Go en consola G&W $consola 1MB sin CFW" \
-    --yesno "Se recomienda realizar el proceso con la batería cargada al 100% para evitar problemas. Se flasheara solamente el emulador Retro-Go por lo que no tendremos el menu original. Las roms que existan en /home/$usuario/game-and-watch-retro-go/roms/ tambien se subiran a la consola." 0 0
+    dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+           --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+           --yesno "¡¡¡ATENCION!!! El proceso RESTAURACION de los save states puede llegar a tardar varios minutos dependiendo de la cantidad de roms que haya en la G&W y pararlo puede ocasionar errores. ¿Deseas continuar?" 0 0
     ans=$?
     if [ $ans -eq 0 ]; then
         clear
-        echo " "
-        echo -e "\e[1;34mSi ya has ejecutado esta opcion anteriormente y algo ha salido mal desmonta la consola y vuelve a ejecutar esta\e[0m"
-        echo -e "\e[1;34mopcion y, al llegar a este punto, desconecta la bateria y vuelve a conectarla antes de realizar lo siguiente.\e[0m"
-        echo " "
-        echo " "
-        echo -e "\e[0;32mSi durante el siguiente proceso nos dice que ha fallado el flasheo, que no puede conectar y nos pregunta si\e[0m"
-        echo -e "\e[0;32mvamos a hacer un power cycle (quitar bateria, reconectar y encender) pulsaremos el boton de encendido y lo \e[0m"
-        echo -e "\e[0;32mmantendremos pulsado unos segundos, le diremos que si con \"y\" (yes), entonces el proceso continuara.\e[0m"
-        echo -e "\e[1;31mPulsa y manten pulsado el boton de encendido y justo despues pulsa cualquier tecla para continuar...\nATENCION: No sueltes el boton al menos hasta que empiece a borrar la memoria externa (cuando pone \"Erasing xxxx bytes...\" en la pantalla\e[0m"
+        echo -e "\e[1;31mEnciende la consola y entra al menu Retro-Go con los botones LEFT+GAME y dejala esperando en el listado de las roms.\e[0m"
+        echo ""
+        echo -e "\e[1;31mPara continuar con el proceso pulsa cualquier tecla...\e[0m"
         read -n 1 -s -r -p ""
-        cd /home/$usuario/gameandwatch/game-and-watch-retro-go
-        make -j$proc COMPRESS=lzma COVERFLOW=$caratula GNW_TARGET=$consola flash
-        read -n 1 -s -r -p "Presiona cualquier tecla para continuar"
-        dialog --backtitle "G&W - Utilidades de flasheo" \
-        --title "Instalar solo Retro-Go" \
-        --msgbox "Proceso realizado." 0 0
+        cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
+        make -j$proc COMPRESS=lzma COVERFLOW=$caratula GNW_TARGET=$consola flash_saves_restore
+        cd -
+        #sleep 5
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso realizado." 0 0
     else
-        dialog --backtitle "G&W - Utilidades de flasheo" \
-        --title "Instalar solo Retro-Go" \
-        --msgbox "Proceso cancelado." 0 0
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso cancelado." 0 0
     fi
-    cd -
-    ./scene/2.2.1-solo-retro-go-$consola.sh
+    ./scene/2.2.1-save-state-$consola.sh
     clear;;
   3)clear
-    cd /home/$usuario/gameandwatch/game-and-watch-retro-go
-    make clean
-    make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=16 COVERFLOW=$caratula GNW_TARGET=$consola
-    read -n 1 -s -r -p "Presiona cualquier tecla para continuar"
-    cd -
-    ./scene/2.2.1-solo-retro-go-$consola.sh
+    dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+           --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+           --yesno "¡¡¡ATENCION!!! El proceso BORRAR los save states puede llegar a tardar varios minutos dependiendo de la cantidad de roms que haya en la G&W y pararlo puede ocasionar errores. ¿Deseas continuar?" 0 0
+    ans=$?
+    if [ $ans -eq 0 ]; then
+        clear
+        echo -e "\e[1;31mEnciende la consola y entra al menu Retro-Go con los botones LEFT+GAME y dejala esperando en el listado de las roms.\e[0m"
+        echo ""
+        echo -e "\e[1;31mPara continuar con el proceso pulsa cualquier tecla...\e[0m"
+        read -n 1 -s -r -p ""
+        cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
+        make -j$proc COMPRESS=lzma COVERFLOW=$caratula GNW_TARGET=$consola flash_saves_erase
+        cd -
+        #sleep 5
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso realizado." 0 0
+    else
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso cancelado." 0 0
+    fi
+    ./scene/2.2.1-save-state-$consola.sh
     clear;;
   4)clear
-    #./scene/2.2.1-retro-go-16mb-$consola.sh
-    clear
-    dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-solo-retro-go-mario.sh Usuario = $usuario ------------------" \
-    --title "Instalar solo Retro-Go en consola G&W $consola 16MB sin CFW" \
-    --yesno "Se recomienda realizar el proceso con la batería cargada al 100% para evitar problemas. Se flasheara solamente el emulador Retro-Go por lo que no tendremos el menu original. Las roms que existan en /home/$usuario/game-and-watch-retro-go/roms/ tambien se subiran a la consola." 0 0
+    dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+           --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+           --yesno "¡¡¡ATENCION!!! El proceso de BACKUP de los save states puede llegar a tardar varios minutos dependiendo de la cantidad de roms que haya en la G&W y pararlo puede ocasionar errores. ¿Deseas continuar?" 0 0
     ans=$?
     if [ $ans -eq 0 ]; then
         clear
-        echo " "
-        echo -e "\e[1;34mSi ya has ejecutado esta opcion anteriormente y algo ha salido mal desmonta la consola y vuelve a ejecutar esta\e[0m"
-        echo -e "\e[1;34mopcion y, al llegar a este punto, desconecta la bateria y vuelve a conectarla antes de realizar lo siguiente.\e[0m"
-        echo " "
-        echo " "
-        echo -e "\e[0;32mSi durante el siguiente proceso nos dice que ha fallado el flasheo, que no puede conectar y nos pregunta si\e[0m"
-        echo -e "\e[0;32mvamos a hacer un power cycle (quitar bateria, reconectar y encender) pulsaremos el boton de encendido y lo \e[0m"
-        echo -e "\e[0;32mmantendremos pulsado unos segundos, le diremos que si con \"y\" (yes), entonces el proceso continuara.\e[0m"
-        echo -e "\e[1;31mPulsa y manten pulsado el boton de encendido y justo despues pulsa cualquier tecla para continuar...\nATENCION: No sueltes el boton al menos hasta que empiece a borrar la memoria externa (cuando pone \"Erasing xxxx bytes...\" en la pantalla\e[0m"
+        echo -e "\e[1;31mEnciende la consola y entra al menu Retro-Go con los botones LEFT+GAME y dejala esperando en el listado de las roms.\e[0m"
+        echo ""
+        echo -e "\e[1;31mPara continuar con el proceso pulsa cualquier tecla...\e[0m"
         read -n 1 -s -r -p ""
-        cd /home/$usuario/gameandwatch/game-and-watch-retro-go
-        make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=16 COVERFLOW=$caratula GNW_TARGET=$consola flash
-        read -n 1 -s -r -p "Presiona cualquier tecla para continuar"
-        dialog --backtitle "G&W - Utilidades de flasheo" \
-        --title "Instalar solo Retro-Go" \
-        --msgbox "Proceso realizado." 0 0
+        cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
+        make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=16 COVERFLOW=$caratula GNW_TARGET=$consola flash_saves_backup
+        cd -
+        #sleep 5
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso realizado. Save states descargados en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" 0 0
     else
-        dialog --backtitle "G&W - Utilidades de flasheo" \
-        --title "Instalar solo Retro-Go" \
-        --msgbox "Proceso cancelado." 0 0
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso cancelado." 0 0
     fi
-    cd -
-    ./scene/2.2.1-solo-retro-go-$consola.sh
+    ./scene/2.2.1-save-state-$consola.sh
     clear;;
   5)clear
-    cd /home/$usuario/gameandwatch/game-and-watch-retro-go
-    make clean
-    make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=64 COVERFLOW=$caratula GNW_TARGET=$consola
-    read -n 1 -s -r -p "Presiona cualquier tecla para continuar"
-    cd -
-    ./scene/2.2.1-solo-retro-go-$consola.sh
-    clear;;
-  6)clear
-    #./scene/2.2.1-retro-go-64mb-$consola.sh
-    clear
-    dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-solo-retro-go-mario.sh Usuario = $usuario ------------------" \
-    --title "Instalar solo Retro-Go en consola G&W $consola 64MB sin CFW" \
-    --yesno "Se recomienda realizar el proceso con la batería cargada al 100% para evitar problemas. Se flasheara solamente el emulador Retro-Go por lo que no tendremos el menu original. Las roms que existan en /home/$usuario/game-and-watch-retro-go/roms/ tambien se subiran a la consola." 0 0
+    dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+           --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+           --yesno "¡¡¡ATENCION!!! El proceso RESTAURACION de los save states puede llegar a tardar varios minutos dependiendo de la cantidad de roms que haya en la G&W y pararlo puede ocasionar errores. ¿Deseas continuar?" 0 0
     ans=$?
     if [ $ans -eq 0 ]; then
         clear
-        echo " "
-        echo -e "\e[1;34mSi ya has ejecutado esta opcion anteriormente y algo ha salido mal desmonta la consola y vuelve a ejecutar esta\e[0m"
-        echo -e "\e[1;34mopcion y, al llegar a este punto, desconecta la bateria y vuelve a conectarla antes de realizar lo siguiente.\e[0m"
-        echo " "
-        echo " "
-        echo -e "\e[0;32mSi durante el siguiente proceso nos dice que ha fallado el flasheo, que no puede conectar y nos pregunta si\e[0m"
-        echo -e "\e[0;32mvamos a hacer un power cycle (quitar bateria, reconectar y encender) pulsaremos el boton de encendido y lo \e[0m"
-        echo -e "\e[0;32mmantendremos pulsado unos segundos, le diremos que si con \"y\" (yes), entonces el proceso continuara.\e[0m"
-        echo -e "\e[1;31mPulsa y manten pulsado el boton de encendido y justo despues pulsa cualquier tecla para continuar...\nATENCION: No sueltes el boton al menos hasta que empiece a borrar la memoria externa (cuando pone \"Erasing xxxx bytes...\" en la pantalla\e[0m"
+        echo -e "\e[1;31mEnciende la consola y entra al menu Retro-Go con los botones LEFT+GAME y dejala esperando en el listado de las roms.\e[0m"
+        echo ""
+        echo -e "\e[1;31mPara continuar con el proceso pulsa cualquier tecla...\e[0m"
         read -n 1 -s -r -p ""
-        cd /home/$usuario/gameandwatch/game-and-watch-retro-go
-        make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=64 COVERFLOW=$caratula GNW_TARGET=$consola flash
-        read -n 1 -s -r -p "Presiona cualquier tecla para continuar"
-        dialog --backtitle "G&W - Utilidades de flasheo" \
-        --title "Instalar solo Retro-Go" \
-        --msgbox "Proceso realizado." 0 0
+        cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
+        make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=16 COVERFLOW=$caratula GNW_TARGET=$consola flash_saves_restore
+        cd -
+        #sleep 5
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso realizado." 0 0
     else
-        dialog --backtitle "G&W - Utilidades de flasheo" \
-        --title "Instalar solo Retro-Go" \
-        --msgbox "Proceso cancelado." 0 0
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso cancelado." 0 0
     fi
-    cd -
-    ./scene/2.2.1-solo-retro-go-$consola.sh
+    ./scene/2.2.1-save-state-$consola.sh
+    clear;;
+  6)clear
+    dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+           --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+           --yesno "¡¡¡ATENCION!!! El proceso BORRAR los save states puede llegar a tardar varios minutos dependiendo de la cantidad de roms que haya en la G&W y pararlo puede ocasionar errores. ¿Deseas continuar?" 0 0
+    ans=$?
+    if [ $ans -eq 0 ]; then
+        clear
+        echo -e "\e[1;31mEnciende la consola y entra al menu Retro-Go con los botones LEFT+GAME y dejala esperando en el listado de las roms.\e[0m"
+        echo ""
+        echo -e "\e[1;31mPara continuar con el proceso pulsa cualquier tecla...\e[0m"
+        read -n 1 -s -r -p ""
+        cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
+        make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=16 COVERFLOW=$caratula GNW_TARGET=$consola flash_saves_erase
+        cd -
+        #sleep 5
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso realizado." 0 0
+    else
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso cancelado." 0 0
+    fi
+    ./scene/2.2.1-save-state-$consola.sh
+    clear;;
+  7)clear
+    dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+           --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+           --yesno "¡¡¡ATENCION!!! El proceso de BACKUP de los save states puede llegar a tardar varios minutos dependiendo de la cantidad de roms que haya en la G&W y pararlo puede ocasionar errores. ¿Deseas continuar?" 0 0
+    ans=$?
+    if [ $ans -eq 0 ]; then
+        clear
+        echo -e "\e[1;31mEnciende la consola y entra al menu Retro-Go con los botones LEFT+GAME y dejala esperando en el listado de las roms.\e[0m"
+        echo ""
+        echo -e "\e[1;31mPara continuar con el proceso pulsa cualquier tecla...\e[0m"
+        read -n 1 -s -r -p ""
+        cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
+        make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=64 COVERFLOW=$caratula GNW_TARGET=$consola flash_saves_backup
+        cd -
+        #sleep 5
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso realizado. Save states descargados en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" 0 0
+    else
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso cancelado." 0 0
+    fi
+    ./scene/2.2.1-save-state-$consola.sh
+    clear;;
+  8)clear
+    dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+           --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+           --yesno "¡¡¡ATENCION!!! El proceso RESTAURACION de los save states puede llegar a tardar varios minutos dependiendo de la cantidad de roms que haya en la G&W y pararlo puede ocasionar errores. ¿Deseas continuar?" 0 0
+    ans=$?
+    if [ $ans -eq 0 ]; then
+        clear
+        echo -e "\e[1;31mEnciende la consola y entra al menu Retro-Go con los botones LEFT+GAME y dejala esperando en el listado de las roms.\e[0m"
+        echo ""
+        echo -e "\e[1;31mPara continuar con el proceso pulsa cualquier tecla...\e[0m"
+        read -n 1 -s -r -p ""
+        cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
+        make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=64 COVERFLOW=$caratula GNW_TARGET=$consola flash_saves_restore
+        cd -
+        #sleep 5
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso realizado." 0 0
+    else
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso cancelado." 0 0
+    fi
+    ./scene/2.2.1-save-state-$consola.sh
+    clear;;
+  9)clear
+    dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+           --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+           --yesno "¡¡¡ATENCION!!! El proceso BORRAR los save states puede llegar a tardar varios minutos dependiendo de la cantidad de roms que haya en la G&W y pararlo puede ocasionar errores. ¿Deseas continuar?" 0 0
+    ans=$?
+    if [ $ans -eq 0 ]; then
+        clear
+        echo -e "\e[1;31mEnciende la consola y entra al menu Retro-Go con los botones LEFT+GAME y dejala esperando en el listado de las roms.\e[0m"
+        echo ""
+        echo -e "\e[1;31mPara continuar con el proceso pulsa cualquier tecla...\e[0m"
+        read -n 1 -s -r -p ""
+        cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
+        make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=64 COVERFLOW=$caratula GNW_TARGET=$consola flash_saves_erase
+        cd -
+        #sleep 5
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso realizado." 0 0
+    else
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso cancelado." 0 0
+    fi
+    ./scene/2.2.1-save-state-$consola.sh
     clear;;
 esac
 clear

--- a/scene/2.2.1-save-state-mario.sh
+++ b/scene/2.2.1-save-state-mario.sh
@@ -5,7 +5,7 @@ INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="mario"
 proc="4"
-caratula="1"
+caratula="0"
 
 clear
 dpkg -s libncurses5 > libncurses5.txt
@@ -53,7 +53,8 @@ case $menuitem in
         cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
         make -j$proc COMPRESS=lzma COVERFLOW=$caratula GNW_TARGET=$consola flash_saves_backup
         cd -
-        #sleep 5
+        echo -e "\e[1;31mPulsa cualquier tecla para continuar...\e[0m"
+        read -n 1 -s -r -p ""
         dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
                --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
                --msgbox "Proceso realizado. Save states descargados en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" 0 0
@@ -78,7 +79,8 @@ case $menuitem in
         cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
         make -j$proc COMPRESS=lzma COVERFLOW=$caratula GNW_TARGET=$consola flash_saves_restore
         cd -
-        #sleep 5
+        echo -e "\e[1;31mPulsa cualquier tecla para continuar...\e[0m"
+        read -n 1 -s -r -p ""
         dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
                --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
                --msgbox "Proceso realizado." 0 0
@@ -103,7 +105,8 @@ case $menuitem in
         cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
         make -j$proc COMPRESS=lzma COVERFLOW=$caratula GNW_TARGET=$consola flash_saves_erase
         cd -
-        #sleep 5
+        echo -e "\e[1;31mPulsa cualquier tecla para continuar...\e[0m"
+        read -n 1 -s -r -p ""
         dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
                --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
                --msgbox "Proceso realizado." 0 0
@@ -128,7 +131,8 @@ case $menuitem in
         cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
         make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=16 COVERFLOW=$caratula GNW_TARGET=$consola flash_saves_backup
         cd -
-        #sleep 5
+        echo -e "\e[1;31mPulsa cualquier tecla para continuar...\e[0m"
+        read -n 1 -s -r -p ""
         dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
                --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
                --msgbox "Proceso realizado. Save states descargados en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" 0 0
@@ -153,7 +157,8 @@ case $menuitem in
         cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
         make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=16 COVERFLOW=$caratula GNW_TARGET=$consola flash_saves_restore
         cd -
-        #sleep 5
+        echo -e "\e[1;31mPulsa cualquier tecla para continuar...\e[0m"
+        read -n 1 -s -r -p ""
         dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
                --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
                --msgbox "Proceso realizado." 0 0
@@ -178,7 +183,8 @@ case $menuitem in
         cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
         make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=16 COVERFLOW=$caratula GNW_TARGET=$consola flash_saves_erase
         cd -
-        #sleep 5
+        echo -e "\e[1;31mPulsa cualquier tecla para continuar...\e[0m"
+        read -n 1 -s -r -p ""
         dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
                --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
                --msgbox "Proceso realizado." 0 0
@@ -203,7 +209,8 @@ case $menuitem in
         cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
         make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=64 COVERFLOW=$caratula GNW_TARGET=$consola flash_saves_backup
         cd -
-        #sleep 5
+        echo -e "\e[1;31mPulsa cualquier tecla para continuar...\e[0m"
+        read -n 1 -s -r -p ""
         dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
                --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
                --msgbox "Proceso realizado. Save states descargados en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" 0 0
@@ -228,7 +235,8 @@ case $menuitem in
         cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
         make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=64 COVERFLOW=$caratula GNW_TARGET=$consola flash_saves_restore
         cd -
-        #sleep 5
+        echo -e "\e[1;31mPulsa cualquier tecla para continuar...\e[0m"
+        read -n 1 -s -r -p ""
         dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
                --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
                --msgbox "Proceso realizado." 0 0
@@ -253,7 +261,8 @@ case $menuitem in
         cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
         make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=64 COVERFLOW=$caratula GNW_TARGET=$consola flash_saves_erase
         cd -
-        #sleep 5
+        echo -e "\e[1;31mPulsa cualquier tecla para continuar...\e[0m"
+        read -n 1 -s -r -p ""
         dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
                --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
                --msgbox "Proceso realizado." 0 0

--- a/scene/2.2.1-save-state-mario.sh
+++ b/scene/2.2.1-save-state-mario.sh
@@ -1,0 +1,148 @@
+#!/bin/bash
+#By julenvitoria
+
+INPUT=/tmp/$MENU.sh.$$
+usuario="kde"
+consola="mario"
+proc="4"
+caratula="0"
+
+dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-solo-retro-go-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+--title "G&W $consola menu Retro-Go + custom firmware" \
+--msgbox "El flasheo se puede realizar para diferentes memorias, elige la mas conveniente a tu hardware. NOTA: Se recomienda realizar el proceso con la batería cargada al 100% para evitar sustos." 0 0
+dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-solo-retro-go-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+--title "G&W $consola CFW + Retro-Go /// INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Roms en /home/$usuario/game-and-watch-retro-go/roms/" \
+--ok-label Apply \
+--cancel-label Exit \
+--menu "Selecciona con las flechas la opcion deseada:" 14 140 15 \
+   1 "Compilar Retro-Go para consola original sin CFW con 1MB" \
+   2 "Subir solo Retro-Go sin CFW en consola original con 1MB" \
+   3 "Compilar Retro-Go para consola sin CFW con chip de 16MB" \
+   4 "Subir solo Retro-Go sin CFW en consola con chip de 16MB" \
+   5 "Compilar Retro-Go para consola sin CFW con chip de 64MB" \
+   6 "Subir solo Retro-Go sin CFW en consola con chip de 64MB"   2>"${INPUT}"
+menuitem=$(<"${INPUT}")
+case $menuitem in
+  1)clear
+    cd /home/$usuario/gameandwatch/game-and-watch-retro-go
+    make clean
+    make -j$proc COMPRESS=lzma COVERFLOW=$caratula GNW_TARGET=$consola
+    read -n 1 -s -r -p "Presiona cualquier tecla para continuar"
+    cd -
+    ./scene/2.2.1-solo-retro-go-$consola.sh
+    clear;;
+  2)clear
+    dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-solo-retro-go-mario.sh Usuario = $usuario ------------------" \
+    --title "Instalar solo Retro-Go en consola G&W $consola 1MB sin CFW" \
+    --yesno "Se recomienda realizar el proceso con la batería cargada al 100% para evitar problemas. Se flasheara solamente el emulador Retro-Go por lo que no tendremos el menu original. Las roms que existan en /home/$usuario/game-and-watch-retro-go/roms/ tambien se subiran a la consola." 0 0
+    ans=$?
+    if [ $ans -eq 0 ]; then
+        clear
+        echo " "
+        echo -e "\e[1;34mSi ya has ejecutado esta opcion anteriormente y algo ha salido mal desmonta la consola y vuelve a ejecutar esta\e[0m"
+        echo -e "\e[1;34mopcion y, al llegar a este punto, desconecta la bateria y vuelve a conectarla antes de realizar lo siguiente.\e[0m"
+        echo " "
+        echo " "
+        echo -e "\e[0;32mSi durante el siguiente proceso nos dice que ha fallado el flasheo, que no puede conectar y nos pregunta si\e[0m"
+        echo -e "\e[0;32mvamos a hacer un power cycle (quitar bateria, reconectar y encender) pulsaremos el boton de encendido y lo \e[0m"
+        echo -e "\e[0;32mmantendremos pulsado unos segundos, le diremos que si con \"y\" (yes), entonces el proceso continuara.\e[0m"
+        echo -e "\e[1;31mPulsa y manten pulsado el boton de encendido y justo despues pulsa cualquier tecla para continuar...\nATENCION: No sueltes el boton al menos hasta que empiece a borrar la memoria externa (cuando pone \"Erasing xxxx bytes...\" en la pantalla\e[0m"
+        read -n 1 -s -r -p ""
+        cd /home/$usuario/gameandwatch/game-and-watch-retro-go
+        make -j$proc COMPRESS=lzma COVERFLOW=$caratula GNW_TARGET=$consola flash
+        read -n 1 -s -r -p "Presiona cualquier tecla para continuar"
+        dialog --backtitle "G&W - Utilidades de flasheo" \
+        --title "Instalar solo Retro-Go" \
+        --msgbox "Proceso realizado." 0 0
+    else
+        dialog --backtitle "G&W - Utilidades de flasheo" \
+        --title "Instalar solo Retro-Go" \
+        --msgbox "Proceso cancelado." 0 0
+    fi
+    cd -
+    ./scene/2.2.1-solo-retro-go-$consola.sh
+    clear;;
+  3)clear
+    cd /home/$usuario/gameandwatch/game-and-watch-retro-go
+    make clean
+    make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=16 COVERFLOW=$caratula GNW_TARGET=$consola
+    read -n 1 -s -r -p "Presiona cualquier tecla para continuar"
+    cd -
+    ./scene/2.2.1-solo-retro-go-$consola.sh
+    clear;;
+  4)clear
+    #./scene/2.2.1-retro-go-16mb-$consola.sh
+    clear
+    dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-solo-retro-go-mario.sh Usuario = $usuario ------------------" \
+    --title "Instalar solo Retro-Go en consola G&W $consola 16MB sin CFW" \
+    --yesno "Se recomienda realizar el proceso con la batería cargada al 100% para evitar problemas. Se flasheara solamente el emulador Retro-Go por lo que no tendremos el menu original. Las roms que existan en /home/$usuario/game-and-watch-retro-go/roms/ tambien se subiran a la consola." 0 0
+    ans=$?
+    if [ $ans -eq 0 ]; then
+        clear
+        echo " "
+        echo -e "\e[1;34mSi ya has ejecutado esta opcion anteriormente y algo ha salido mal desmonta la consola y vuelve a ejecutar esta\e[0m"
+        echo -e "\e[1;34mopcion y, al llegar a este punto, desconecta la bateria y vuelve a conectarla antes de realizar lo siguiente.\e[0m"
+        echo " "
+        echo " "
+        echo -e "\e[0;32mSi durante el siguiente proceso nos dice que ha fallado el flasheo, que no puede conectar y nos pregunta si\e[0m"
+        echo -e "\e[0;32mvamos a hacer un power cycle (quitar bateria, reconectar y encender) pulsaremos el boton de encendido y lo \e[0m"
+        echo -e "\e[0;32mmantendremos pulsado unos segundos, le diremos que si con \"y\" (yes), entonces el proceso continuara.\e[0m"
+        echo -e "\e[1;31mPulsa y manten pulsado el boton de encendido y justo despues pulsa cualquier tecla para continuar...\nATENCION: No sueltes el boton al menos hasta que empiece a borrar la memoria externa (cuando pone \"Erasing xxxx bytes...\" en la pantalla\e[0m"
+        read -n 1 -s -r -p ""
+        cd /home/$usuario/gameandwatch/game-and-watch-retro-go
+        make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=16 COVERFLOW=$caratula GNW_TARGET=$consola flash
+        read -n 1 -s -r -p "Presiona cualquier tecla para continuar"
+        dialog --backtitle "G&W - Utilidades de flasheo" \
+        --title "Instalar solo Retro-Go" \
+        --msgbox "Proceso realizado." 0 0
+    else
+        dialog --backtitle "G&W - Utilidades de flasheo" \
+        --title "Instalar solo Retro-Go" \
+        --msgbox "Proceso cancelado." 0 0
+    fi
+    cd -
+    ./scene/2.2.1-solo-retro-go-$consola.sh
+    clear;;
+  5)clear
+    cd /home/$usuario/gameandwatch/game-and-watch-retro-go
+    make clean
+    make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=64 COVERFLOW=$caratula GNW_TARGET=$consola
+    read -n 1 -s -r -p "Presiona cualquier tecla para continuar"
+    cd -
+    ./scene/2.2.1-solo-retro-go-$consola.sh
+    clear;;
+  6)clear
+    #./scene/2.2.1-retro-go-64mb-$consola.sh
+    clear
+    dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-solo-retro-go-mario.sh Usuario = $usuario ------------------" \
+    --title "Instalar solo Retro-Go en consola G&W $consola 64MB sin CFW" \
+    --yesno "Se recomienda realizar el proceso con la batería cargada al 100% para evitar problemas. Se flasheara solamente el emulador Retro-Go por lo que no tendremos el menu original. Las roms que existan en /home/$usuario/game-and-watch-retro-go/roms/ tambien se subiran a la consola." 0 0
+    ans=$?
+    if [ $ans -eq 0 ]; then
+        clear
+        echo " "
+        echo -e "\e[1;34mSi ya has ejecutado esta opcion anteriormente y algo ha salido mal desmonta la consola y vuelve a ejecutar esta\e[0m"
+        echo -e "\e[1;34mopcion y, al llegar a este punto, desconecta la bateria y vuelve a conectarla antes de realizar lo siguiente.\e[0m"
+        echo " "
+        echo " "
+        echo -e "\e[0;32mSi durante el siguiente proceso nos dice que ha fallado el flasheo, que no puede conectar y nos pregunta si\e[0m"
+        echo -e "\e[0;32mvamos a hacer un power cycle (quitar bateria, reconectar y encender) pulsaremos el boton de encendido y lo \e[0m"
+        echo -e "\e[0;32mmantendremos pulsado unos segundos, le diremos que si con \"y\" (yes), entonces el proceso continuara.\e[0m"
+        echo -e "\e[1;31mPulsa y manten pulsado el boton de encendido y justo despues pulsa cualquier tecla para continuar...\nATENCION: No sueltes el boton al menos hasta que empiece a borrar la memoria externa (cuando pone \"Erasing xxxx bytes...\" en la pantalla\e[0m"
+        read -n 1 -s -r -p ""
+        cd /home/$usuario/gameandwatch/game-and-watch-retro-go
+        make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=64 COVERFLOW=$caratula GNW_TARGET=$consola flash
+        read -n 1 -s -r -p "Presiona cualquier tecla para continuar"
+        dialog --backtitle "G&W - Utilidades de flasheo" \
+        --title "Instalar solo Retro-Go" \
+        --msgbox "Proceso realizado." 0 0
+    else
+        dialog --backtitle "G&W - Utilidades de flasheo" \
+        --title "Instalar solo Retro-Go" \
+        --msgbox "Proceso cancelado." 0 0
+    fi
+    cd -
+    ./scene/2.2.1-solo-retro-go-$consola.sh
+    clear;;
+esac
+clear

--- a/scene/2.2.1-save-state-mario.sh
+++ b/scene/2.2.1-save-state-mario.sh
@@ -5,12 +5,9 @@ INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="mario"
 proc="4"
-caratula="0"
+caratula="1"
 
-dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-solo-retro-go-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
---title "G&W $consola menu Retro-Go + custom firmware" \
---msgbox "El flasheo se puede realizar para diferentes memorias, elige la mas conveniente a tu hardware. NOTA: Se recomienda realizar el proceso con la batería cargada al 100% para evitar sustos." 0 0
-dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-solo-retro-go-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
 --title "G&W $consola CFW + Retro-Go /// INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Roms en /home/$usuario/game-and-watch-retro-go/roms/" \
 --ok-label Apply \
 --cancel-label Exit \

--- a/scene/2.2.1-save-state-zelda.sh
+++ b/scene/2.2.1-save-state-zelda.sh
@@ -7,138 +7,261 @@ consola="zelda"
 proc="4"
 caratula="1"
 
+clear
+dpkg -s libncurses5 > libncurses5.txt
+if grep "install ok installed" ./libncurses5.txt ; then
+        echo "Encontrado paquete libncurses5, se prosigue..."
+        sleep 0.5
+else
+        echo "No encontrado paquete dialog necesario, instalando..."
+        echo " "
+        sudo apt install -y libncurses5
+        echo " "
+        echo "Instalado!!"
+        sleep 0.5
+fi
+
 dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
---title "G&W $consola CFW + Retro-Go /// INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Roms en /home/$usuario/game-and-watch-retro-go/roms/" \
---ok-label Apply \
---cancel-label Exit \
---menu "Selecciona con las flechas la opcion deseada:" 14 140 15 \
-   1 "prueba" \
-   2 "Subir solo Retro-Go sin CFW en consola original con 4MB" \
-   3 "Compilar Retro-Go para consola sin CFW con chip de 16MB" \
-   4 "Subir solo Retro-Go sin CFW en consola con chip de 16MB" \
-   5 "Compilar Retro-Go para consola sin CFW con chip de 64MB" \
-   6 "Subir solo Retro-Go sin CFW en consola con chip de 64MB"
-   7 "Descarga y restauracion de saves-states con parametros \"solo retro-go\""   2>"${INPUT}"
+       --msgbox "G&W Utilidad para backup, resturacion y borrado de save states. Una vez descargados los save states estan ubicados en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" 0 0
+dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+       --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+       --ok-label Apply \
+       --cancel-label Exit \
+       --menu "Selecciona con las flechas la opcion deseada:" 16 140 15 \
+          1 "4MB $consola solo Retro-Go: Hacer backup de los save states existentes que hay en la G&W" \
+          2 "4MB $consola solo Retro-Go: Restaurar los save states desde el pc a la G&W" \
+          3 "4MB $consola solo Retro-Go: Borrar los saves states existentes en la G&W para dejarla limpia" \
+          4 "16MB $consola solo Retro-Go: Hacer backup de los save states existentes que hay en la G&W" \
+          5 "16MB $consola solo Retro-Go: Restaurar los save states desde el pc a la G&W" \
+          6 "16MB $consola solo Retro-Go: Borrar los saves states existentes en la G&W" \
+          7 "64MB $consola solo Retro-Go: Hacer backup de los save states existentes que hay en la G&W" \
+          8 "64MB $consola solo Retro-Go: Restaurar los save states desde el pc a la G&W" \
+          9 "64MB $consola solo Retro-Go: Borrar los saves states existentes en la G&W"   2>"${INPUT}"
 menuitem=$(<"${INPUT}")
 case $menuitem in
   1)clear
-    cd /home/$usuario/gameandwatch/game-and-watch-retro-go
-    make clean
-    make -j$proc COMPRESS=lzma COVERFLOW=$caratula GNW_TARGET=$consola
-    read -n 1 -s -r -p "Presiona cualquier tecla para continuar"
-    cd -
-    ./scene/2.2.1-solo-retro-go-$consola.sh
+    dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+           --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+           --yesno "¡¡¡ATENCION!!! El proceso de BACKUP de los save states puede llegar a tardar varios minutos dependiendo de la cantidad de roms que haya en la G&W y pararlo puede ocasionar errores. ¿Deseas continuar?" 0 0
+    ans=$?
+    if [ $ans -eq 0 ]; then
+        clear
+        echo -e "\e[1;31mEnciende la consola y entra al menu Retro-Go con los botones LEFT+GAME y dejala esperando en el listado de las roms.\e[0m"
+        echo ""
+        echo -e "\e[1;31mPara continuar con el proceso pulsa cualquier tecla...\e[0m"
+        read -n 1 -s -r -p ""
+        cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
+        make -j$proc COMPRESS=lzma COVERFLOW=$caratula GNW_TARGET=$consola flash_saves_backup
+        cd -
+        #sleep 5
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso realizado. Save states descargados en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" 0 0
+    else
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso cancelado." 0 0
+    fi
+    ./scene/2.2.1-save-state-$consola.sh
     clear;;
   2)clear
-    dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-solo-retro-go-zelda.sh Usuario = $usuario ------------------" \
-    --title "Instalar solo Retro-Go en consola G&W $consola 4MB sin CFW" \
-    --yesno "Se recomienda realizar el proceso con la batería cargada al 100% para evitar problemas. Se flasheara solamente el emulador Retro-Go por lo que no tendremos el menu original. Las roms que existan en /home/$usuario/game-and-watch-retro-go/roms/ tambien se subiran a la consola." 0 0
+    dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+           --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+           --yesno "¡¡¡ATENCION!!! El proceso RESTAURACION de los save states puede llegar a tardar varios minutos dependiendo de la cantidad de roms que haya en la G&W y pararlo puede ocasionar errores. ¿Deseas continuar?" 0 0
     ans=$?
     if [ $ans -eq 0 ]; then
         clear
-        echo " "
-        echo -e "\e[1;34mSi ya has ejecutado esta opcion anteriormente y algo ha salido mal desmonta la consola y vuelve a ejecutar esta\e[0m"
-        echo -e "\e[1;34mopcion y, al llegar a este punto, desconecta la bateria y vuelve a conectarla antes de realizar lo siguiente.\e[0m"
-        echo " "
-        echo " "
-        echo -e "\e[0;32mSi durante el siguiente proceso nos dice que ha fallado el flasheo, que no puede conectar y nos pregunta si\e[0m"
-        echo -e "\e[0;32mvamos a hacer un power cycle (quitar bateria, reconectar y encender) pulsaremos el boton de encendido y lo \e[0m"
-        echo -e "\e[0;32mmantendremos pulsado unos segundos, le diremos que si con \"y\" (yes), entonces el proceso continuara.\e[0m"
-        echo -e "\e[1;31mPulsa y manten pulsado el boton de encendido y justo despues pulsa cualquier tecla para continuar...\nATENCION: No sueltes el boton al menos hasta que empiece a borrar la memoria externa (cuando pone \"Erasing xxxx bytes...\" en la pantalla\e[0m"
+        echo -e "\e[1;31mEnciende la consola y entra al menu Retro-Go con los botones LEFT+GAME y dejala esperando en el listado de las roms.\e[0m"
+        echo ""
+        echo -e "\e[1;31mPara continuar con el proceso pulsa cualquier tecla...\e[0m"
         read -n 1 -s -r -p ""
-        cd /home/$usuario/gameandwatch/game-and-watch-retro-go
-        make -j$proc COMPRESS=lzma COVERFLOW=$caratula GNW_TARGET=$consola flash
-        read -n 1 -s -r -p "Presiona cualquier tecla para continuar"
-        dialog --backtitle "G&W - Utilidades de flasheo" \
-        --title "Instalar solo Retro-Go" \
-        --msgbox "Proceso realizado." 0 0
+        cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
+        make -j$proc COMPRESS=lzma COVERFLOW=$caratula GNW_TARGET=$consola flash_saves_restore
+        cd -
+        #sleep 5
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso realizado." 0 0
     else
-        dialog --backtitle "G&W - Utilidades de flasheo" \
-        --title "Instalar solo Retro-Go" \
-        --msgbox "Proceso cancelado." 0 0
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso cancelado." 0 0
     fi
-    cd -
-    ./scene/2.2.1-solo-retro-go-zelda.sh
+    ./scene/2.2.1-save-state-$consola.sh
     clear;;
   3)clear
-    cd /home/$usuario/gameandwatch/game-and-watch-retro-go
-    make clean
-    make -j$proc EXTFLASH_SIZE_MB=16 COVERFLOW=$caratula GNW_TARGET=$consola
-    read -n 1 -s -r -p "Presiona cualquier tecla para continuar"
-    cd -
-    ./scene/2.2.1-solo-retro-go-$consola.sh
+    dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+           --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+           --yesno "¡¡¡ATENCION!!! El proceso BORRAR los save states puede llegar a tardar varios minutos dependiendo de la cantidad de roms que haya en la G&W y pararlo puede ocasionar errores. ¿Deseas continuar?" 0 0
+    ans=$?
+    if [ $ans -eq 0 ]; then
+        clear
+        echo -e "\e[1;31mEnciende la consola y entra al menu Retro-Go con los botones LEFT+GAME y dejala esperando en el listado de las roms.\e[0m"
+        echo ""
+        echo -e "\e[1;31mPara continuar con el proceso pulsa cualquier tecla...\e[0m"
+        read -n 1 -s -r -p ""
+        cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
+        make -j$proc COMPRESS=lzma COVERFLOW=$caratula GNW_TARGET=$consola flash_saves_erase
+        cd -
+        #sleep 5
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso realizado." 0 0
+    else
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso cancelado." 0 0
+    fi
+    ./scene/2.2.1-save-state-$consola.sh
     clear;;
   4)clear
-    dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-solo-retro-go-zelda.sh Usuario = $usuario ------------------" \
-    --title "Instalar solo Retro-Go en consola G&W $consola 16MB sin CFW" \
-    --yesno "Se recomienda realizar el proceso con la batería cargada al 100% para evitar problemas. Se flasheara solamente el emulador Retro-Go por lo que no tendremos el menu original. Las roms que existan en /home/$usuario/game-and-watch-retro-go/roms/ tambien se subiran a la consola." 0 0
+    dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+           --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+           --yesno "¡¡¡ATENCION!!! El proceso de BACKUP de los save states puede llegar a tardar varios minutos dependiendo de la cantidad de roms que haya en la G&W y pararlo puede ocasionar errores. ¿Deseas continuar?" 0 0
     ans=$?
     if [ $ans -eq 0 ]; then
         clear
-        echo " "
-        echo -e "\e[1;34mSi ya has ejecutado esta opcion anteriormente y algo ha salido mal desmonta la consola y vuelve a ejecutar esta\e[0m"
-        echo -e "\e[1;34mopcion y, al llegar a este punto, desconecta la bateria y vuelve a conectarla antes de realizar lo siguiente.\e[0m"
-        echo " "
-        echo " "
-        echo -e "\e[0;32mSi durante el siguiente proceso nos dice que ha fallado el flasheo, que no puede conectar y nos pregunta si\e[0m"
-        echo -e "\e[0;32mvamos a hacer un power cycle (quitar bateria, reconectar y encender) pulsaremos el boton de encendido y lo \e[0m"
-        echo -e "\e[0;32mmantendremos pulsado unos segundos, le diremos que si con \"y\" (yes), entonces el proceso continuara.\e[0m"
-        echo -e "\e[1;31mPulsa y manten pulsado el boton de encendido y justo despues pulsa cualquier tecla para continuar...\nATENCION: No sueltes el boton al menos hasta que empiece a borrar la memoria externa (cuando pone \"Erasing xxxx bytes...\" en la pantalla\e[0m"
+        echo -e "\e[1;31mEnciende la consola y entra al menu Retro-Go con los botones LEFT+GAME y dejala esperando en el listado de las roms.\e[0m"
+        echo ""
+        echo -e "\e[1;31mPara continuar con el proceso pulsa cualquier tecla...\e[0m"
         read -n 1 -s -r -p ""
-        cd /home/$usuario/gameandwatch/game-and-watch-retro-go
-        make -j$proc EXTFLASH_SIZE_MB=16 COVERFLOW=$caratula GNW_TARGET=$consola flash
-        read -n 1 -s -r -p "Presiona cualquier tecla para continuar"
-        dialog --backtitle "G&W - Utilidades de flasheo" \
-        --title "Instalar solo Retro-Go" \
-        --msgbox "Proceso realizado." 0 0
+        cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
+        make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=16 COVERFLOW=$caratula GNW_TARGET=$consola flash_saves_backup
+        cd -
+        #sleep 5
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso realizado. Save states descargados en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" 0 0
     else
-        dialog --backtitle "G&W - Utilidades de flasheo" \
-        --title "Instalar solo Retro-Go" \
-        --msgbox "Proceso cancelado." 0 0
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso cancelado." 0 0
     fi
-    cd -
-    ./scene/2.2.1-solo-retro-go-zelda.sh
+    ./scene/2.2.1-save-state-$consola.sh
     clear;;
   5)clear
-    cd /home/$usuario/gameandwatch/game-and-watch-retro-go
-    make clean
-    make -j$proc EXTFLASH_SIZE_MB=64 COVERFLOW=$caratula GNW_TARGET=$consola
-    read -n 1 -s -r -p "Presiona cualquier tecla para continuar"
-    cd -
-    ./scene/2.2.1-solo-retro-go-$consola.sh
-    clear;;
-  6)clear
-    dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-solo-retro-go-zelda.sh Usuario = $usuario ------------------" \
-    --title "Instalar solo Retro-Go en consola G&W $consola 64MB sin CFW" \
-    --yesno "Se recomienda realizar el proceso con la batería cargada al 100% para evitar problemas. Se flasheara solamente el emulador Retro-Go por lo que no tendremos el menu original. Las roms que existan en /home/$usuario/game-and-watch-retro-go/roms/ tambien se subiran a la consola." 0 0
+    dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+           --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+           --yesno "¡¡¡ATENCION!!! El proceso RESTAURACION de los save states puede llegar a tardar varios minutos dependiendo de la cantidad de roms que haya en la G&W y pararlo puede ocasionar errores. ¿Deseas continuar?" 0 0
     ans=$?
     if [ $ans -eq 0 ]; then
         clear
-        echo " "
-        echo -e "\e[1;34mSi ya has ejecutado esta opcion anteriormente y algo ha salido mal desmonta la consola y vuelve a ejecutar esta\e[0m"
-        echo -e "\e[1;34mopcion y, al llegar a este punto, desconecta la bateria y vuelve a conectarla antes de realizar lo siguiente.\e[0m"
-        echo " "
-        echo " "
-        echo -e "\e[0;32mSi durante el siguiente proceso nos dice que ha fallado el flasheo, que no puede conectar y nos pregunta si\e[0m"
-        echo -e "\e[0;32mvamos a hacer un power cycle (quitar bateria, reconectar y encender) pulsaremos el boton de encendido y lo \e[0m"
-        echo -e "\e[0;32mmantendremos pulsado unos segundos, le diremos que si con \"y\" (yes), entonces el proceso continuara.\e[0m"
-        echo -e "\e[1;31mPulsa y manten pulsado el boton de encendido y justo despues pulsa cualquier tecla para continuar...\nATENCION: No sueltes el boton al menos hasta que empiece a borrar la memoria externa (cuando pone \"Erasing xxxx bytes...\" en la pantalla\e[0m"
+        echo -e "\e[1;31mEnciende la consola y entra al menu Retro-Go con los botones LEFT+GAME y dejala esperando en el listado de las roms.\e[0m"
+        echo ""
+        echo -e "\e[1;31mPara continuar con el proceso pulsa cualquier tecla...\e[0m"
         read -n 1 -s -r -p ""
-        cd /home/$usuario/gameandwatch/game-and-watch-retro-go
-        make -j$proc EXTFLASH_SIZE_MB=64 COVERFLOW=$caratula GNW_TARGET=$consola flash
-        read -n 1 -s -r -p "Presiona cualquier tecla para continuar"
-        dialog --backtitle "G&W - Utilidades de flasheo" \
-        --title "Instalar solo Retro-Go" \
-        --msgbox "Proceso realizado." 0 0
+        cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
+        make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=16 COVERFLOW=$caratula GNW_TARGET=$consola flash_saves_restore
+        cd -
+        #sleep 5
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso realizado." 0 0
     else
-        dialog --backtitle "G&W - Utilidades de flasheo" \
-        --title "Instalar solo Retro-Go" \
-        --msgbox "Proceso cancelado." 0 0
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso cancelado." 0 0
     fi
-    cd -
-    ./scene/2.2.1-solo-retro-go-zelda.sh
+    ./scene/2.2.1-save-state-$consola.sh
+    clear;;
+  6)clear
+    dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+           --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+           --yesno "¡¡¡ATENCION!!! El proceso BORRAR los save states puede llegar a tardar varios minutos dependiendo de la cantidad de roms que haya en la G&W y pararlo puede ocasionar errores. ¿Deseas continuar?" 0 0
+    ans=$?
+    if [ $ans -eq 0 ]; then
+        clear
+        echo -e "\e[1;31mEnciende la consola y entra al menu Retro-Go con los botones LEFT+GAME y dejala esperando en el listado de las roms.\e[0m"
+        echo ""
+        echo -e "\e[1;31mPara continuar con el proceso pulsa cualquier tecla...\e[0m"
+        read -n 1 -s -r -p ""
+        cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
+        make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=16 COVERFLOW=$caratula GNW_TARGET=$consola flash_saves_erase
+        cd -
+        #sleep 5
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso realizado." 0 0
+    else
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso cancelado." 0 0
+    fi
+    ./scene/2.2.1-save-state-$consola.sh
     clear;;
   7)clear
+    dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+           --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+           --yesno "¡¡¡ATENCION!!! El proceso de BACKUP de los save states puede llegar a tardar varios minutos dependiendo de la cantidad de roms que haya en la G&W y pararlo puede ocasionar errores. ¿Deseas continuar?" 0 0
+    ans=$?
+    if [ $ans -eq 0 ]; then
+        clear
+        echo -e "\e[1;31mEnciende la consola y entra al menu Retro-Go con los botones LEFT+GAME y dejala esperando en el listado de las roms.\e[0m"
+        echo ""
+        echo -e "\e[1;31mPara continuar con el proceso pulsa cualquier tecla...\e[0m"
+        read -n 1 -s -r -p ""
+        cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
+        make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=64 COVERFLOW=$caratula GNW_TARGET=$consola flash_saves_backup
+        cd -
+        #sleep 5
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso realizado. Save states descargados en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" 0 0
+    else
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso cancelado." 0 0
+    fi
+    ./scene/2.2.1-save-state-$consola.sh
+    clear;;
+  8)clear
+    dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+           --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+           --yesno "¡¡¡ATENCION!!! El proceso RESTAURACION de los save states puede llegar a tardar varios minutos dependiendo de la cantidad de roms que haya en la G&W y pararlo puede ocasionar errores. ¿Deseas continuar?" 0 0
+    ans=$?
+    if [ $ans -eq 0 ]; then
+        clear
+        echo -e "\e[1;31mEnciende la consola y entra al menu Retro-Go con los botones LEFT+GAME y dejala esperando en el listado de las roms.\e[0m"
+        echo ""
+        echo -e "\e[1;31mPara continuar con el proceso pulsa cualquier tecla...\e[0m"
+        read -n 1 -s -r -p ""
+        cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
+        make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=64 COVERFLOW=$caratula GNW_TARGET=$consola flash_saves_restore
+        cd -
+        #sleep 5
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso realizado." 0 0
+    else
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso cancelado." 0 0
+    fi
+    ./scene/2.2.1-save-state-$consola.sh
+    clear;;
+  9)clear
+    dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+           --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+           --yesno "¡¡¡ATENCION!!! El proceso BORRAR los save states puede llegar a tardar varios minutos dependiendo de la cantidad de roms que haya en la G&W y pararlo puede ocasionar errores. ¿Deseas continuar?" 0 0
+    ans=$?
+    if [ $ans -eq 0 ]; then
+        clear
+        echo -e "\e[1;31mEnciende la consola y entra al menu Retro-Go con los botones LEFT+GAME y dejala esperando en el listado de las roms.\e[0m"
+        echo ""
+        echo -e "\e[1;31mPara continuar con el proceso pulsa cualquier tecla...\e[0m"
+        read -n 1 -s -r -p ""
+        cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
+        make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=64 COVERFLOW=$caratula GNW_TARGET=$consola flash_saves_erase
+        cd -
+        #sleep 5
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso realizado." 0 0
+    else
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso cancelado." 0 0
+    fi
     ./scene/2.2.1-save-state-$consola.sh
     clear;;
 esac

--- a/scene/2.2.1-save-state-zelda.sh
+++ b/scene/2.2.1-save-state-zelda.sh
@@ -5,7 +5,7 @@ INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="zelda"
 proc="4"
-caratula="1"
+caratula="0"
 
 clear
 dpkg -s libncurses5 > libncurses5.txt
@@ -53,7 +53,8 @@ case $menuitem in
         cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
         make -j$proc COMPRESS=lzma COVERFLOW=$caratula GNW_TARGET=$consola flash_saves_backup
         cd -
-        #sleep 5
+        echo -e "\e[1;31mPulsa cualquier tecla para continuar...\e[0m"
+        read -n 1 -s -r -p ""
         dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
                --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
                --msgbox "Proceso realizado. Save states descargados en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" 0 0
@@ -78,7 +79,8 @@ case $menuitem in
         cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
         make -j$proc COMPRESS=lzma COVERFLOW=$caratula GNW_TARGET=$consola flash_saves_restore
         cd -
-        #sleep 5
+        echo -e "\e[1;31mPulsa cualquier tecla para continuar...\e[0m"
+        read -n 1 -s -r -p ""
         dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
                --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
                --msgbox "Proceso realizado." 0 0
@@ -103,7 +105,8 @@ case $menuitem in
         cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
         make -j$proc COMPRESS=lzma COVERFLOW=$caratula GNW_TARGET=$consola flash_saves_erase
         cd -
-        #sleep 5
+        echo -e "\e[1;31mPulsa cualquier tecla para continuar...\e[0m"
+        read -n 1 -s -r -p ""
         dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
                --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
                --msgbox "Proceso realizado." 0 0
@@ -128,7 +131,8 @@ case $menuitem in
         cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
         make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=16 COVERFLOW=$caratula GNW_TARGET=$consola flash_saves_backup
         cd -
-        #sleep 5
+        echo -e "\e[1;31mPulsa cualquier tecla para continuar...\e[0m"
+        read -n 1 -s -r -p ""
         dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
                --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
                --msgbox "Proceso realizado. Save states descargados en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" 0 0
@@ -153,7 +157,8 @@ case $menuitem in
         cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
         make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=16 COVERFLOW=$caratula GNW_TARGET=$consola flash_saves_restore
         cd -
-        #sleep 5
+        echo -e "\e[1;31mPulsa cualquier tecla para continuar...\e[0m"
+        read -n 1 -s -r -p ""
         dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
                --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
                --msgbox "Proceso realizado." 0 0
@@ -178,7 +183,8 @@ case $menuitem in
         cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
         make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=16 COVERFLOW=$caratula GNW_TARGET=$consola flash_saves_erase
         cd -
-        #sleep 5
+        echo -e "\e[1;31mPulsa cualquier tecla para continuar...\e[0m"
+        read -n 1 -s -r -p ""
         dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
                --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
                --msgbox "Proceso realizado." 0 0
@@ -203,7 +209,8 @@ case $menuitem in
         cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
         make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=64 COVERFLOW=$caratula GNW_TARGET=$consola flash_saves_backup
         cd -
-        #sleep 5
+        echo -e "\e[1;31mPulsa cualquier tecla para continuar...\e[0m"
+        read -n 1 -s -r -p ""
         dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
                --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
                --msgbox "Proceso realizado. Save states descargados en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" 0 0
@@ -228,7 +235,8 @@ case $menuitem in
         cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
         make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=64 COVERFLOW=$caratula GNW_TARGET=$consola flash_saves_restore
         cd -
-        #sleep 5
+        echo -e "\e[1;31mPulsa cualquier tecla para continuar...\e[0m"
+        read -n 1 -s -r -p ""
         dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
                --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
                --msgbox "Proceso realizado." 0 0
@@ -253,7 +261,8 @@ case $menuitem in
         cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
         make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=64 COVERFLOW=$caratula GNW_TARGET=$consola flash_saves_erase
         cd -
-        #sleep 5
+        echo -e "\e[1;31mPulsa cualquier tecla para continuar...\e[0m"
+        read -n 1 -s -r -p ""
         dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
                --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
                --msgbox "Proceso realizado." 0 0

--- a/scene/2.2.1-save-state-zelda.sh
+++ b/scene/2.2.1-save-state-zelda.sh
@@ -4,7 +4,7 @@
 INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="zelda"
-proc="6"
+proc="4"
 caratula="0"
 
 clear

--- a/scene/2.2.1-save-state-zelda.sh
+++ b/scene/2.2.1-save-state-zelda.sh
@@ -15,12 +15,13 @@ dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO
 --ok-label Apply \
 --cancel-label Exit \
 --menu "Selecciona con las flechas la opcion deseada:" 14 140 15 \
-   1 "Compilar Retro-Go para consola original sin CFW con 4MB" \
+   1 "prueba" \
    2 "Subir solo Retro-Go sin CFW en consola original con 4MB" \
    3 "Compilar Retro-Go para consola sin CFW con chip de 16MB" \
    4 "Subir solo Retro-Go sin CFW en consola con chip de 16MB" \
    5 "Compilar Retro-Go para consola sin CFW con chip de 64MB" \
-   6 "Subir solo Retro-Go sin CFW en consola con chip de 64MB"   2>"${INPUT}"
+   6 "Subir solo Retro-Go sin CFW en consola con chip de 64MB"
+   7 "Descarga y restauracion de saves-states con parametros \"solo retro-go\""   2>"${INPUT}"
 menuitem=$(<"${INPUT}")
 case $menuitem in
   1)clear
@@ -139,6 +140,9 @@ case $menuitem in
     fi
     cd -
     ./scene/2.2.1-solo-retro-go-zelda.sh
+    clear;;
+  7)clear
+    ./scene/2.2.1-save-state-$consola.sh
     clear;;
 esac
 clear

--- a/scene/2.2.1-save-state-zelda.sh
+++ b/scene/2.2.1-save-state-zelda.sh
@@ -4,7 +4,7 @@
 INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="zelda"
-proc="4"
+proc="6"
 caratula="0"
 
 clear
@@ -27,7 +27,13 @@ dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO
        --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
        --ok-label Apply \
        --cancel-label Exit \
-       --menu "Selecciona con las flechas la opcion deseada:" 16 140 15 \
+       --menu "
+Usuario actual: $usuario
+Consola seleccionada: $consola
+Opcion caratulas: $caratula (0=NO y 1=SI)
+Save states: /home/$usuario/game-and-watch-retro-go/save_states/
+
+Selecciona con las flechas la opcion deseada:" 0 0 0 \
           1 "4MB $consola solo Retro-Go: Hacer backup de los save states existentes que hay en la G&W" \
           2 "4MB $consola solo Retro-Go: Restaurar los save states desde el pc a la G&W" \
           3 "4MB $consola solo Retro-Go: Borrar los saves states existentes en la G&W para dejarla limpia" \

--- a/scene/2.2.1-save-state-zelda.sh
+++ b/scene/2.2.1-save-state-zelda.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+#By julenvitoria
+
+INPUT=/tmp/$MENU.sh.$$
+usuario="kde"
+consola="zelda"
+proc="4"
+caratula="0"
+
+dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-solo-retro-go-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+--title "G&W $consola menu Retro-Go + custom firmware" \
+--msgbox "El flasheo se puede realizar para diferentes memorias, elige la mas conveniente a tu hardware. NOTA: Se recomienda realizar el proceso con la batería cargada al 100% para evitar sustos." 0 0
+dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-solo-retro-go-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+--title "G&W $consola CFW + Retro-Go /// INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Roms en /home/$usuario/game-and-watch-retro-go/roms/" \
+--ok-label Apply \
+--cancel-label Exit \
+--menu "Selecciona con las flechas la opcion deseada:" 14 140 15 \
+   1 "Compilar Retro-Go para consola original sin CFW con 4MB" \
+   2 "Subir solo Retro-Go sin CFW en consola original con 4MB" \
+   3 "Compilar Retro-Go para consola sin CFW con chip de 16MB" \
+   4 "Subir solo Retro-Go sin CFW en consola con chip de 16MB" \
+   5 "Compilar Retro-Go para consola sin CFW con chip de 64MB" \
+   6 "Subir solo Retro-Go sin CFW en consola con chip de 64MB"   2>"${INPUT}"
+menuitem=$(<"${INPUT}")
+case $menuitem in
+  1)clear
+    cd /home/$usuario/gameandwatch/game-and-watch-retro-go
+    make clean
+    make -j$proc COMPRESS=lzma COVERFLOW=$caratula GNW_TARGET=$consola
+    read -n 1 -s -r -p "Presiona cualquier tecla para continuar"
+    cd -
+    ./scene/2.2.1-solo-retro-go-$consola.sh
+    clear;;
+  2)clear
+    dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-solo-retro-go-zelda.sh Usuario = $usuario ------------------" \
+    --title "Instalar solo Retro-Go en consola G&W $consola 4MB sin CFW" \
+    --yesno "Se recomienda realizar el proceso con la batería cargada al 100% para evitar problemas. Se flasheara solamente el emulador Retro-Go por lo que no tendremos el menu original. Las roms que existan en /home/$usuario/game-and-watch-retro-go/roms/ tambien se subiran a la consola." 0 0
+    ans=$?
+    if [ $ans -eq 0 ]; then
+        clear
+        echo " "
+        echo -e "\e[1;34mSi ya has ejecutado esta opcion anteriormente y algo ha salido mal desmonta la consola y vuelve a ejecutar esta\e[0m"
+        echo -e "\e[1;34mopcion y, al llegar a este punto, desconecta la bateria y vuelve a conectarla antes de realizar lo siguiente.\e[0m"
+        echo " "
+        echo " "
+        echo -e "\e[0;32mSi durante el siguiente proceso nos dice que ha fallado el flasheo, que no puede conectar y nos pregunta si\e[0m"
+        echo -e "\e[0;32mvamos a hacer un power cycle (quitar bateria, reconectar y encender) pulsaremos el boton de encendido y lo \e[0m"
+        echo -e "\e[0;32mmantendremos pulsado unos segundos, le diremos que si con \"y\" (yes), entonces el proceso continuara.\e[0m"
+        echo -e "\e[1;31mPulsa y manten pulsado el boton de encendido y justo despues pulsa cualquier tecla para continuar...\nATENCION: No sueltes el boton al menos hasta que empiece a borrar la memoria externa (cuando pone \"Erasing xxxx bytes...\" en la pantalla\e[0m"
+        read -n 1 -s -r -p ""
+        cd /home/$usuario/gameandwatch/game-and-watch-retro-go
+        make -j$proc COMPRESS=lzma COVERFLOW=$caratula GNW_TARGET=$consola flash
+        read -n 1 -s -r -p "Presiona cualquier tecla para continuar"
+        dialog --backtitle "G&W - Utilidades de flasheo" \
+        --title "Instalar solo Retro-Go" \
+        --msgbox "Proceso realizado." 0 0
+    else
+        dialog --backtitle "G&W - Utilidades de flasheo" \
+        --title "Instalar solo Retro-Go" \
+        --msgbox "Proceso cancelado." 0 0
+    fi
+    cd -
+    ./scene/2.2.1-solo-retro-go-zelda.sh
+    clear;;
+  3)clear
+    cd /home/$usuario/gameandwatch/game-and-watch-retro-go
+    make clean
+    make -j$proc EXTFLASH_SIZE_MB=16 COVERFLOW=$caratula GNW_TARGET=$consola
+    read -n 1 -s -r -p "Presiona cualquier tecla para continuar"
+    cd -
+    ./scene/2.2.1-solo-retro-go-$consola.sh
+    clear;;
+  4)clear
+    dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-solo-retro-go-zelda.sh Usuario = $usuario ------------------" \
+    --title "Instalar solo Retro-Go en consola G&W $consola 16MB sin CFW" \
+    --yesno "Se recomienda realizar el proceso con la batería cargada al 100% para evitar problemas. Se flasheara solamente el emulador Retro-Go por lo que no tendremos el menu original. Las roms que existan en /home/$usuario/game-and-watch-retro-go/roms/ tambien se subiran a la consola." 0 0
+    ans=$?
+    if [ $ans -eq 0 ]; then
+        clear
+        echo " "
+        echo -e "\e[1;34mSi ya has ejecutado esta opcion anteriormente y algo ha salido mal desmonta la consola y vuelve a ejecutar esta\e[0m"
+        echo -e "\e[1;34mopcion y, al llegar a este punto, desconecta la bateria y vuelve a conectarla antes de realizar lo siguiente.\e[0m"
+        echo " "
+        echo " "
+        echo -e "\e[0;32mSi durante el siguiente proceso nos dice que ha fallado el flasheo, que no puede conectar y nos pregunta si\e[0m"
+        echo -e "\e[0;32mvamos a hacer un power cycle (quitar bateria, reconectar y encender) pulsaremos el boton de encendido y lo \e[0m"
+        echo -e "\e[0;32mmantendremos pulsado unos segundos, le diremos que si con \"y\" (yes), entonces el proceso continuara.\e[0m"
+        echo -e "\e[1;31mPulsa y manten pulsado el boton de encendido y justo despues pulsa cualquier tecla para continuar...\nATENCION: No sueltes el boton al menos hasta que empiece a borrar la memoria externa (cuando pone \"Erasing xxxx bytes...\" en la pantalla\e[0m"
+        read -n 1 -s -r -p ""
+        cd /home/$usuario/gameandwatch/game-and-watch-retro-go
+        make -j$proc EXTFLASH_SIZE_MB=16 COVERFLOW=$caratula GNW_TARGET=$consola flash
+        read -n 1 -s -r -p "Presiona cualquier tecla para continuar"
+        dialog --backtitle "G&W - Utilidades de flasheo" \
+        --title "Instalar solo Retro-Go" \
+        --msgbox "Proceso realizado." 0 0
+    else
+        dialog --backtitle "G&W - Utilidades de flasheo" \
+        --title "Instalar solo Retro-Go" \
+        --msgbox "Proceso cancelado." 0 0
+    fi
+    cd -
+    ./scene/2.2.1-solo-retro-go-zelda.sh
+    clear;;
+  5)clear
+    cd /home/$usuario/gameandwatch/game-and-watch-retro-go
+    make clean
+    make -j$proc EXTFLASH_SIZE_MB=64 COVERFLOW=$caratula GNW_TARGET=$consola
+    read -n 1 -s -r -p "Presiona cualquier tecla para continuar"
+    cd -
+    ./scene/2.2.1-solo-retro-go-$consola.sh
+    clear;;
+  6)clear
+    dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-solo-retro-go-zelda.sh Usuario = $usuario ------------------" \
+    --title "Instalar solo Retro-Go en consola G&W $consola 64MB sin CFW" \
+    --yesno "Se recomienda realizar el proceso con la batería cargada al 100% para evitar problemas. Se flasheara solamente el emulador Retro-Go por lo que no tendremos el menu original. Las roms que existan en /home/$usuario/game-and-watch-retro-go/roms/ tambien se subiran a la consola." 0 0
+    ans=$?
+    if [ $ans -eq 0 ]; then
+        clear
+        echo " "
+        echo -e "\e[1;34mSi ya has ejecutado esta opcion anteriormente y algo ha salido mal desmonta la consola y vuelve a ejecutar esta\e[0m"
+        echo -e "\e[1;34mopcion y, al llegar a este punto, desconecta la bateria y vuelve a conectarla antes de realizar lo siguiente.\e[0m"
+        echo " "
+        echo " "
+        echo -e "\e[0;32mSi durante el siguiente proceso nos dice que ha fallado el flasheo, que no puede conectar y nos pregunta si\e[0m"
+        echo -e "\e[0;32mvamos a hacer un power cycle (quitar bateria, reconectar y encender) pulsaremos el boton de encendido y lo \e[0m"
+        echo -e "\e[0;32mmantendremos pulsado unos segundos, le diremos que si con \"y\" (yes), entonces el proceso continuara.\e[0m"
+        echo -e "\e[1;31mPulsa y manten pulsado el boton de encendido y justo despues pulsa cualquier tecla para continuar...\nATENCION: No sueltes el boton al menos hasta que empiece a borrar la memoria externa (cuando pone \"Erasing xxxx bytes...\" en la pantalla\e[0m"
+        read -n 1 -s -r -p ""
+        cd /home/$usuario/gameandwatch/game-and-watch-retro-go
+        make -j$proc EXTFLASH_SIZE_MB=64 COVERFLOW=$caratula GNW_TARGET=$consola flash
+        read -n 1 -s -r -p "Presiona cualquier tecla para continuar"
+        dialog --backtitle "G&W - Utilidades de flasheo" \
+        --title "Instalar solo Retro-Go" \
+        --msgbox "Proceso realizado." 0 0
+    else
+        dialog --backtitle "G&W - Utilidades de flasheo" \
+        --title "Instalar solo Retro-Go" \
+        --msgbox "Proceso cancelado." 0 0
+    fi
+    cd -
+    ./scene/2.2.1-solo-retro-go-zelda.sh
+    clear;;
+esac
+clear

--- a/scene/2.2.1-save-state-zelda.sh
+++ b/scene/2.2.1-save-state-zelda.sh
@@ -5,12 +5,9 @@ INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="zelda"
 proc="4"
-caratula="0"
+caratula="1"
 
-dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-solo-retro-go-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
---title "G&W $consola menu Retro-Go + custom firmware" \
---msgbox "El flasheo se puede realizar para diferentes memorias, elige la mas conveniente a tu hardware. NOTA: Se recomienda realizar el proceso con la batería cargada al 100% para evitar sustos." 0 0
-dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-solo-retro-go-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
 --title "G&W $consola CFW + Retro-Go /// INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Roms en /home/$usuario/game-and-watch-retro-go/roms/" \
 --ok-label Apply \
 --cancel-label Exit \

--- a/scene/2.2.1-solo-retro-go-mario.sh
+++ b/scene/2.2.1-solo-retro-go-mario.sh
@@ -21,6 +21,7 @@ Opcion caratulas: $caratula (0=NO y 1=SI)
 Roms: /home/$usuario/game-and-watch-retro-go/roms/
 
 Selecciona con las flechas la opcion deseada:" 0 0 0 \
+   H "Herramientas y utilidades" \
    1 "1MB: Compilar solo Retro-Go sin CFW para consola $consola original sin CFW" \
    2 "1MB: Flashear solo Retro-Go sin CFW en consola $consola original sin CFW" \
    3 "16MB: Compilar solo Retro-Go sin CFW para consola $consola sin CFW" \
@@ -30,6 +31,10 @@ Selecciona con las flechas la opcion deseada:" 0 0 0 \
    7 "Descarga y restauracion de saves-states con parametros \"solo retro-go\""   2>"${INPUT}"
 menuitem=$(<"${INPUT}")
 case $menuitem in
+  H)clear
+    ./scene/2.2.H-opcion-herramientas.sh
+    ./scene/2.2.1-solo-retro-go-$consola.sh
+    clear;;
   1)clear
     cd /home/$usuario/gameandwatch/game-and-watch-retro-go
     make clean

--- a/scene/2.2.1-solo-retro-go-mario.sh
+++ b/scene/2.2.1-solo-retro-go-mario.sh
@@ -5,7 +5,7 @@ INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="mario"
 proc="4"
-caratula="1"
+caratula="0"
 
 dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-solo-retro-go-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
 --title "G&W $consola menu Retro-Go + custom firmware" \

--- a/scene/2.2.1-solo-retro-go-mario.sh
+++ b/scene/2.2.1-solo-retro-go-mario.sh
@@ -16,11 +16,11 @@ dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO
 --cancel-label Exit \
 --menu "Selecciona con las flechas la opcion deseada:" 14 140 15 \
    1 "Compilar Retro-Go para consola original sin CFW con 1MB" \
-   2 "Subir solo Retro-Go sin CFW en consola original con 1MB" \
+   2 "Flashear solo Retro-Go sin CFW en consola original con 1MB" \
    3 "Compilar Retro-Go para consola sin CFW con chip de 16MB" \
-   4 "Subir solo Retro-Go sin CFW en consola con chip de 16MB" \
+   4 "Flashear solo Retro-Go sin CFW en consola con chip de 16MB" \
    5 "Compilar Retro-Go para consola sin CFW con chip de 64MB" \
-   6 "Subir solo Retro-Go sin CFW en consola con chip de 64MB" \
+   6 "Flashear solo Retro-Go sin CFW en consola con chip de 64MB" \
    7 "Descarga y restauracion de saves-states con parametros \"solo retro-go\""   2>"${INPUT}"
 menuitem=$(<"${INPUT}")
 case $menuitem in

--- a/scene/2.2.1-solo-retro-go-mario.sh
+++ b/scene/2.2.1-solo-retro-go-mario.sh
@@ -15,12 +15,12 @@ dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO
 --ok-label Apply \
 --cancel-label Exit \
 --menu "Selecciona con las flechas la opcion deseada:" 14 140 15 \
-   1 "Compilar Retro-Go para consola original sin CFW con 1MB" \
-   2 "Flashear solo Retro-Go sin CFW en consola original con 1MB" \
-   3 "Compilar Retro-Go para consola sin CFW con chip de 16MB" \
-   4 "Flashear solo Retro-Go sin CFW en consola con chip de 16MB" \
-   5 "Compilar Retro-Go para consola sin CFW con chip de 64MB" \
-   6 "Flashear solo Retro-Go sin CFW en consola con chip de 64MB" \
+   1 "1MB Compilar solo Retro-Go sin CFW para consola $consola original sin CFW" \
+   2 "1MB Flashear solo Retro-Go sin CFW en consola $consola original" \
+   3 "16MB Compilar solo Retro-Go sin CFW para consola $consola" \
+   4 "16MB Flashear solo Retro-Go sin CFW en consola G&W $consola" \
+   5 "64MB Compilar solo Retro-Go sin CFW para consola $consola" \
+   6 "64MB Flashear solo Retro-Go sin CFW en consola $consola" \
    7 "Descarga y restauracion de saves-states con parametros \"solo retro-go\""   2>"${INPUT}"
 menuitem=$(<"${INPUT}")
 case $menuitem in
@@ -147,6 +147,7 @@ case $menuitem in
     clear;;
   7)clear
     ./scene/2.2.1-save-state-$consola.sh
+    ./scene/2.2.1-solo-retro-go-$consola.sh
     clear;;
 esac
 clear

--- a/scene/2.2.1-solo-retro-go-mario.sh
+++ b/scene/2.2.1-solo-retro-go-mario.sh
@@ -5,7 +5,7 @@ INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="mario"
 proc="4"
-caratula="0"
+caratula="1"
 
 dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-solo-retro-go-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
 --title "G&W $consola menu Retro-Go + custom firmware" \

--- a/scene/2.2.1-solo-retro-go-mario.sh
+++ b/scene/2.2.1-solo-retro-go-mario.sh
@@ -20,7 +20,8 @@ dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO
    3 "Compilar Retro-Go para consola sin CFW con chip de 16MB" \
    4 "Subir solo Retro-Go sin CFW en consola con chip de 16MB" \
    5 "Compilar Retro-Go para consola sin CFW con chip de 64MB" \
-   6 "Subir solo Retro-Go sin CFW en consola con chip de 64MB"   2>"${INPUT}"
+   6 "Subir solo Retro-Go sin CFW en consola con chip de 64MB" \
+   7 "Descarga y restauracion de saves-states con parametros \"solo retro-go\""   2>"${INPUT}"
 menuitem=$(<"${INPUT}")
 case $menuitem in
   1)clear
@@ -143,6 +144,9 @@ case $menuitem in
     fi
     cd -
     ./scene/2.2.1-solo-retro-go-$consola.sh
+    clear;;
+  7)clear
+    ./scene/2.2.1-save-state-$consola.sh
     clear;;
 esac
 clear

--- a/scene/2.2.1-solo-retro-go-mario.sh
+++ b/scene/2.2.1-solo-retro-go-mario.sh
@@ -4,7 +4,7 @@
 INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="mario"
-proc="4"
+proc="6"
 caratula="0"
 
 dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-solo-retro-go-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
@@ -14,13 +14,19 @@ dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO
 --title "G&W $consola CFW + Retro-Go /// INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Roms en /home/$usuario/game-and-watch-retro-go/roms/" \
 --ok-label Apply \
 --cancel-label Exit \
---menu "Selecciona con las flechas la opcion deseada:" 14 140 15 \
+--menu "
+Usuario actual: $usuario
+Consola seleccionada: $consola
+Opcion caratulas: $caratula (0=NO y 1=SI)
+Roms: /home/$usuario/game-and-watch-retro-go/roms/
+
+Selecciona con las flechas la opcion deseada:" 0 0 0 \
    1 "1MB: Compilar solo Retro-Go sin CFW para consola $consola original sin CFW" \
-   2 "1MB: Flashear solo Retro-Go sin CFW en consola $consola original" \
-   3 "16MB: Compilar solo Retro-Go sin CFW para consola $consola" \
-   4 "16MB: Flashear solo Retro-Go sin CFW en consola $consola" \
-   5 "64MB: Compilar solo Retro-Go sin CFW para consola $consola" \
-   6 "64MB: Flashear solo Retro-Go sin CFW en consola $consola" \
+   2 "1MB: Flashear solo Retro-Go sin CFW en consola $consola original sin CFW" \
+   3 "16MB: Compilar solo Retro-Go sin CFW para consola $consola sin CFW" \
+   4 "16MB: Flashear solo Retro-Go sin CFW en consola $consola sin CFW" \
+   5 "64MB: Compilar solo Retro-Go sin CFW para consola $consola sin CFW" \
+   6 "64MB: Flashear solo Retro-Go sin CFW en consola $consola sin CFW" \
    7 "Descarga y restauracion de saves-states con parametros \"solo retro-go\""   2>"${INPUT}"
 menuitem=$(<"${INPUT}")
 case $menuitem in

--- a/scene/2.2.1-solo-retro-go-mario.sh
+++ b/scene/2.2.1-solo-retro-go-mario.sh
@@ -15,12 +15,12 @@ dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO
 --ok-label Apply \
 --cancel-label Exit \
 --menu "Selecciona con las flechas la opcion deseada:" 14 140 15 \
-   1 "1MB Compilar solo Retro-Go sin CFW para consola $consola original sin CFW" \
-   2 "1MB Flashear solo Retro-Go sin CFW en consola $consola original" \
-   3 "16MB Compilar solo Retro-Go sin CFW para consola $consola" \
-   4 "16MB Flashear solo Retro-Go sin CFW en consola G&W $consola" \
-   5 "64MB Compilar solo Retro-Go sin CFW para consola $consola" \
-   6 "64MB Flashear solo Retro-Go sin CFW en consola $consola" \
+   1 "1MB: Compilar solo Retro-Go sin CFW para consola $consola original sin CFW" \
+   2 "1MB: Flashear solo Retro-Go sin CFW en consola $consola original" \
+   3 "16MB: Compilar solo Retro-Go sin CFW para consola $consola" \
+   4 "16MB: Flashear solo Retro-Go sin CFW en consola $consola" \
+   5 "64MB: Compilar solo Retro-Go sin CFW para consola $consola" \
+   6 "64MB: Flashear solo Retro-Go sin CFW en consola $consola" \
    7 "Descarga y restauracion de saves-states con parametros \"solo retro-go\""   2>"${INPUT}"
 menuitem=$(<"${INPUT}")
 case $menuitem in
@@ -72,8 +72,6 @@ case $menuitem in
     ./scene/2.2.1-solo-retro-go-$consola.sh
     clear;;
   4)clear
-    #./scene/2.2.1-retro-go-16mb-$consola.sh
-    clear
     dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-solo-retro-go-mario.sh Usuario = $usuario ------------------" \
     --title "Instalar solo Retro-Go en consola G&W $consola 16MB sin CFW" \
     --yesno "Se recomienda realizar el proceso con la batería cargada al 100% para evitar problemas. Se flasheara solamente el emulador Retro-Go por lo que no tendremos el menu original. Las roms que existan en /home/$usuario/game-and-watch-retro-go/roms/ tambien se subiran a la consola." 0 0
@@ -113,8 +111,6 @@ case $menuitem in
     ./scene/2.2.1-solo-retro-go-$consola.sh
     clear;;
   6)clear
-    #./scene/2.2.1-retro-go-64mb-$consola.sh
-    clear
     dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-solo-retro-go-mario.sh Usuario = $usuario ------------------" \
     --title "Instalar solo Retro-Go en consola G&W $consola 64MB sin CFW" \
     --yesno "Se recomienda realizar el proceso con la batería cargada al 100% para evitar problemas. Se flasheara solamente el emulador Retro-Go por lo que no tendremos el menu original. Las roms que existan en /home/$usuario/game-and-watch-retro-go/roms/ tambien se subiran a la consola." 0 0

--- a/scene/2.2.1-solo-retro-go-mario.sh
+++ b/scene/2.2.1-solo-retro-go-mario.sh
@@ -4,7 +4,7 @@
 INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="mario"
-proc="6"
+proc="4"
 caratula="0"
 
 dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-solo-retro-go-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \

--- a/scene/2.2.1-solo-retro-go-zelda.sh
+++ b/scene/2.2.1-solo-retro-go-zelda.sh
@@ -15,12 +15,12 @@ dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO
 --ok-label Apply \
 --cancel-label Exit \
 --menu "Selecciona con las flechas la opcion deseada:" 14 140 15 \
-   1 "Compilar Retro-Go para consola original sin CFW con 4MB" \
-   2 "Subir solo Retro-Go sin CFW en consola original con 4MB" \
-   3 "Compilar Retro-Go para consola sin CFW con chip de 16MB" \
-   4 "Subir solo Retro-Go sin CFW en consola con chip de 16MB" \
-   5 "Compilar Retro-Go para consola sin CFW con chip de 64MB" \
-   6 "Subir solo Retro-Go sin CFW en consola con chip de 64MB" \
+   1 "4MB: Compilar Retro-Go para consola original sin CFW" \
+   2 "4MB: Subir solo Retro-Go en consola original sin CFW" \
+   3 "416B: Compilar Retro-Go para consola sin CFW" \
+   4 "16MB: Subir solo Retro-Go en consola sin CFW" \
+   5 "64MB: Compilar Retro-Go para consola sin CFW" \
+   6 "64MB: Subir solo Retro-Go en consola sin CFW" \
    7 "Descarga y restauracion de saves-states con parametros \"solo retro-go\""   2>"${INPUT}"
 menuitem=$(<"${INPUT}")
 case $menuitem in
@@ -66,7 +66,7 @@ case $menuitem in
   3)clear
     cd /home/$usuario/gameandwatch/game-and-watch-retro-go
     make clean
-    make -j$proc EXTFLASH_SIZE_MB=16 COVERFLOW=$caratula GNW_TARGET=$consola
+    make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=16 COVERFLOW=$caratula GNW_TARGET=$consola
     read -n 1 -s -r -p "Presiona cualquier tecla para continuar"
     cd -
     ./scene/2.2.1-solo-retro-go-$consola.sh
@@ -89,7 +89,7 @@ case $menuitem in
         echo -e "\e[1;31mPulsa y manten pulsado el boton de encendido y justo despues pulsa cualquier tecla para continuar...\nATENCION: No sueltes el boton al menos hasta que empiece a borrar la memoria externa (cuando pone \"Erasing xxxx bytes...\" en la pantalla\e[0m"
         read -n 1 -s -r -p ""
         cd /home/$usuario/gameandwatch/game-and-watch-retro-go
-        make -j$proc EXTFLASH_SIZE_MB=16 COVERFLOW=$caratula GNW_TARGET=$consola flash
+        make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=16 COVERFLOW=$caratula GNW_TARGET=$consola flash
         read -n 1 -s -r -p "Presiona cualquier tecla para continuar"
         dialog --backtitle "G&W - Utilidades de flasheo" \
         --title "Instalar solo Retro-Go" \
@@ -105,7 +105,7 @@ case $menuitem in
   5)clear
     cd /home/$usuario/gameandwatch/game-and-watch-retro-go
     make clean
-    make -j$proc EXTFLASH_SIZE_MB=64 COVERFLOW=$caratula GNW_TARGET=$consola
+    make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=64 COVERFLOW=$caratula GNW_TARGET=$consola
     read -n 1 -s -r -p "Presiona cualquier tecla para continuar"
     cd -
     ./scene/2.2.1-solo-retro-go-$consola.sh
@@ -128,7 +128,7 @@ case $menuitem in
         echo -e "\e[1;31mPulsa y manten pulsado el boton de encendido y justo despues pulsa cualquier tecla para continuar...\nATENCION: No sueltes el boton al menos hasta que empiece a borrar la memoria externa (cuando pone \"Erasing xxxx bytes...\" en la pantalla\e[0m"
         read -n 1 -s -r -p ""
         cd /home/$usuario/gameandwatch/game-and-watch-retro-go
-        make -j$proc EXTFLASH_SIZE_MB=64 COVERFLOW=$caratula GNW_TARGET=$consola flash
+        make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=64 COVERFLOW=$caratula GNW_TARGET=$consola flash
         read -n 1 -s -r -p "Presiona cualquier tecla para continuar"
         dialog --backtitle "G&W - Utilidades de flasheo" \
         --title "Instalar solo Retro-Go" \

--- a/scene/2.2.1-solo-retro-go-zelda.sh
+++ b/scene/2.2.1-solo-retro-go-zelda.sh
@@ -15,12 +15,12 @@ dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO
 --ok-label Apply \
 --cancel-label Exit \
 --menu "Selecciona con las flechas la opcion deseada:" 14 140 15 \
-   1 "4MB: Compilar Retro-Go para consola original sin CFW" \
-   2 "4MB: Subir solo Retro-Go en consola original sin CFW" \
-   3 "416B: Compilar Retro-Go para consola sin CFW" \
-   4 "16MB: Subir solo Retro-Go en consola sin CFW" \
-   5 "64MB: Compilar Retro-Go para consola sin CFW" \
-   6 "64MB: Subir solo Retro-Go en consola sin CFW" \
+   1 "4MB: Compilar solo Retro-Go sin CFW para consola $consola original sin CFW" \
+   2 "4MB: Flashear solo Retro-Go sin CFW en consola $consola original" \
+   3 "16MB: Compilar solo Retro-Go sin CFW para consola $consola" \
+   4 "16MB: Flashear solo Retro-Go sin CFW en consola $consola" \
+   5 "64MB: Compilar solo Retro-Go sin CFW para consola $consola" \
+   6 "64MB: Flashear solo Retro-Go sin CFW en consola $consola" \
    7 "Descarga y restauracion de saves-states con parametros \"solo retro-go\""   2>"${INPUT}"
 menuitem=$(<"${INPUT}")
 case $menuitem in

--- a/scene/2.2.1-solo-retro-go-zelda.sh
+++ b/scene/2.2.1-solo-retro-go-zelda.sh
@@ -4,7 +4,7 @@
 INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="zelda"
-proc="4"
+proc="6"
 caratula="0"
 
 dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-solo-retro-go-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
@@ -14,13 +14,19 @@ dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO
 --title "G&W $consola CFW + Retro-Go /// INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Roms en /home/$usuario/game-and-watch-retro-go/roms/" \
 --ok-label Apply \
 --cancel-label Exit \
---menu "Selecciona con las flechas la opcion deseada:" 14 140 15 \
+--menu "
+Usuario actual: $usuario
+Consola seleccionada: $consola
+Opcion caratulas: $caratula (0=NO y 1=SI)
+Roms: /home/$usuario/game-and-watch-retro-go/roms/
+
+Selecciona con las flechas la opcion deseada:" 0 0 0 \
    1 "4MB: Compilar solo Retro-Go sin CFW para consola $consola original sin CFW" \
-   2 "4MB: Flashear solo Retro-Go sin CFW en consola $consola original" \
-   3 "16MB: Compilar solo Retro-Go sin CFW para consola $consola" \
-   4 "16MB: Flashear solo Retro-Go sin CFW en consola $consola" \
-   5 "64MB: Compilar solo Retro-Go sin CFW para consola $consola" \
-   6 "64MB: Flashear solo Retro-Go sin CFW en consola $consola" \
+   2 "4MB: Flashear solo Retro-Go sin CFW en consola $consola original sin CFW" \
+   3 "16MB: Compilar solo Retro-Go sin CFW para consola $consola sin CFW" \
+   4 "16MB: Flashear solo Retro-Go sin CFW en consola $consola sin CFW" \
+   5 "64MB: Compilar solo Retro-Go sin CFW para consola $consola sin CFW" \
+   6 "64MB: Flashear solo Retro-Go sin CFW en consola $consola sin CFW" \
    7 "Descarga y restauracion de saves-states con parametros \"solo retro-go\""   2>"${INPUT}"
 menuitem=$(<"${INPUT}")
 case $menuitem in

--- a/scene/2.2.1-solo-retro-go-zelda.sh
+++ b/scene/2.2.1-solo-retro-go-zelda.sh
@@ -61,7 +61,7 @@ case $menuitem in
         --msgbox "Proceso cancelado." 0 0
     fi
     cd -
-    ./scene/2.2.1-solo-retro-go-zelda.sh
+    ./scene/2.2.1-solo-retro-go-$consola.sh
     clear;;
   3)clear
     cd /home/$usuario/gameandwatch/game-and-watch-retro-go
@@ -100,7 +100,7 @@ case $menuitem in
         --msgbox "Proceso cancelado." 0 0
     fi
     cd -
-    ./scene/2.2.1-solo-retro-go-zelda.sh
+    ./scene/2.2.1-solo-retro-go-$consola.sh
     clear;;
   5)clear
     cd /home/$usuario/gameandwatch/game-and-watch-retro-go
@@ -139,10 +139,11 @@ case $menuitem in
         --msgbox "Proceso cancelado." 0 0
     fi
     cd -
-    ./scene/2.2.1-solo-retro-go-zelda.sh
+    ./scene/2.2.1-solo-retro-go-$consola.sh
     clear;;
   7)clear
     ./scene/2.2.1-save-state-$consola.sh
+    ./scene/2.2.1-solo-retro-go-$consola.sh
     clear;;
 esac
 clear

--- a/scene/2.2.1-solo-retro-go-zelda.sh
+++ b/scene/2.2.1-solo-retro-go-zelda.sh
@@ -4,7 +4,7 @@
 INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="zelda"
-proc="6"
+proc="4"
 caratula="0"
 
 dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-solo-retro-go-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
@@ -21,6 +21,7 @@ Opcion caratulas: $caratula (0=NO y 1=SI)
 Roms: /home/$usuario/game-and-watch-retro-go/roms/
 
 Selecciona con las flechas la opcion deseada:" 0 0 0 \
+   H "Herramientas y utilidades" \
    1 "4MB: Compilar solo Retro-Go sin CFW para consola $consola original sin CFW" \
    2 "4MB: Flashear solo Retro-Go sin CFW en consola $consola original sin CFW" \
    3 "16MB: Compilar solo Retro-Go sin CFW para consola $consola sin CFW" \
@@ -30,6 +31,10 @@ Selecciona con las flechas la opcion deseada:" 0 0 0 \
    7 "Descarga y restauracion de saves-states con parametros \"solo retro-go\""   2>"${INPUT}"
 menuitem=$(<"${INPUT}")
 case $menuitem in
+  H)clear
+    ./scene/2.2.H-opcion-herramientas.sh
+    ./scene/2.2.1-solo-retro-go-$consola.sh
+    clear;;
   1)clear
     cd /home/$usuario/gameandwatch/game-and-watch-retro-go
     make clean

--- a/scene/2.2.1-solo-retro-go-zelda.sh
+++ b/scene/2.2.1-solo-retro-go-zelda.sh
@@ -20,7 +20,8 @@ dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO
    3 "Compilar Retro-Go para consola sin CFW con chip de 16MB" \
    4 "Subir solo Retro-Go sin CFW en consola con chip de 16MB" \
    5 "Compilar Retro-Go para consola sin CFW con chip de 64MB" \
-   6 "Subir solo Retro-Go sin CFW en consola con chip de 64MB"   2>"${INPUT}"
+   6 "Subir solo Retro-Go sin CFW en consola con chip de 64MB" \
+   7 "Descarga y restauracion de saves-states con parametros \"solo retro-go\""   2>"${INPUT}"
 menuitem=$(<"${INPUT}")
 case $menuitem in
   1)clear
@@ -139,6 +140,9 @@ case $menuitem in
     fi
     cd -
     ./scene/2.2.1-solo-retro-go-zelda.sh
+    clear;;
+  7)clear
+    ./scene/2.2.1-save-state-$consola.sh
     clear;;
 esac
 clear

--- a/scene/2.2.1-solo-retro-go-zelda.sh
+++ b/scene/2.2.1-solo-retro-go-zelda.sh
@@ -5,7 +5,7 @@ INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="zelda"
 proc="4"
-caratula="1"
+caratula="0"
 
 dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-solo-retro-go-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
 --title "G&W $consola menu Retro-Go + custom firmware" \

--- a/scene/2.2.1-solo-retro-go-zelda.sh
+++ b/scene/2.2.1-solo-retro-go-zelda.sh
@@ -5,7 +5,7 @@ INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="zelda"
 proc="4"
-caratula="0"
+caratula="1"
 
 dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.1-solo-retro-go-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
 --title "G&W $consola menu Retro-Go + custom firmware" \

--- a/scene/2.2.2-cfw-retro-go-1mb-mario.sh
+++ b/scene/2.2.2-cfw-retro-go-1mb-mario.sh
@@ -5,7 +5,7 @@ INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="mario"
 proc="4"
-caratula="1"
+caratula="0"
 
 dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.2-cfw-retro-go-1mb-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
 --title "G&W CFW + Retro-Go 1MB /// INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Roms en /home/$usuario/game-and-watch-retro-go/roms/" \

--- a/scene/2.2.2-cfw-retro-go-1mb-mario.sh
+++ b/scene/2.2.2-cfw-retro-go-1mb-mario.sh
@@ -5,7 +5,7 @@ INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="mario"
 proc="4"
-caratula="0"
+caratula="1"
 
 dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.2-cfw-retro-go-1mb-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
 --title "G&W CFW + Retro-Go 1MB /// INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Roms en /home/$usuario/game-and-watch-retro-go/roms/" \

--- a/scene/2.2.2-cfw-retro-go-1mb-mario.sh
+++ b/scene/2.2.2-cfw-retro-go-1mb-mario.sh
@@ -82,7 +82,7 @@ case $menuitem in
         clear
         cd /home/$usuario/gameandwatch/game-and-watch-retro-go
         make clean
-        make -j$proc COMPRESS=lzma INTFLASH_BANK=2 COVERFLOW=$caratula
+        make -j$proc COMPRESS=lzma INTFLASH_BANK=2 GNW_TARGET=$consola COVERFLOW=$caratula
 		cd -
         echo " "
         echo " "
@@ -116,7 +116,7 @@ case $menuitem in
         read -n 1 -s -r -p ""
         cd /home/$usuario/gameandwatch/game-and-watch-retro-go
         #make clean
-        make -j$proc COMPRESS=lzma INTFLASH_BANK=2 COVERFLOW=$caratula flash
+        make -j$proc COMPRESS=lzma INTFLASH_BANK=2 GNW_TARGET=$consola COVERFLOW=$caratula flash
         cd -
         read -n 1 -s -r -p "Presiona cualquier tecla para continuar"
         dialog --backtitle "G&W $consola - Utilidades de flasheo" \
@@ -131,6 +131,7 @@ case $menuitem in
     clear;;
     4)clear
     ./scene/2.2.2-save-state-$consola.sh
+    ./scene/2.2.2-cfw-retro-go-1mb-$consola.sh
 	clear;;
 esac
 clear

--- a/scene/2.2.2-cfw-retro-go-1mb-mario.sh
+++ b/scene/2.2.2-cfw-retro-go-1mb-mario.sh
@@ -14,7 +14,8 @@ dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO
 --menu "Selecciona con las flechas la opcion deseada:" 12 140 15 \
    1 "CFW con los parametros para 1MB" \
    2 "Compilar Retro-Go con los parametros para 1MB" \
-   3 "Flashear Retro-Go con los parametros para 1MB" 2>"${INPUT}"
+   3 "Flashear Retro-Go con los parametros para 1MB" \
+   4 "Descarga y restauracion de saves-states con parametros 1MB"   2>"${INPUT}"
 menuitem=$(<"${INPUT}")
 case $menuitem in
   1)clear
@@ -128,5 +129,8 @@ case $menuitem in
     fi
     ./scene/2.2.2-cfw-retro-go-1mb-$consola.sh
     clear;;
+    4)clear
+    ./scene/2.2.2-save-state-$consola.sh
+	clear;;
 esac
 clear

--- a/scene/2.2.2-cfw-retro-go-1mb-mario.sh
+++ b/scene/2.2.2-cfw-retro-go-1mb-mario.sh
@@ -18,12 +18,17 @@ Opcion caratulas: $caratula (0=NO y 1=SI)
 Roms: /home/$usuario/game-and-watch-retro-go/roms/
 
 Selecciona con las flechas la opcion deseada:" 0 0 0 \
+   H "Herramientas y utilidades" \
    1 "CFW con los parametros para 1MB" \
    2 "Compilar Retro-Go con los parametros para 1MB" \
    3 "Flashear Retro-Go con los parametros para 1MB" \
    4 "Descarga y restauracion de saves-states con parametros 1MB"   2>"${INPUT}"
 menuitem=$(<"${INPUT}")
 case $menuitem in
+  H)clear
+    ./scene/2.2.H-opcion-herramientas.sh
+    ./scene/2.2.2-cfw-retro-go-1mb-$consola.sh
+    clear;;
   1)clear
     dialog --backtitle "G&W $consola - Utilidades de flasheo" \
     --title "Instalar Retro-Go en consola G&W $consola con 1MB" \

--- a/scene/2.2.2-cfw-retro-go-1mb-mario.sh
+++ b/scene/2.2.2-cfw-retro-go-1mb-mario.sh
@@ -4,14 +4,20 @@
 INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="mario"
-proc="4"
+proc="6"
 caratula="0"
 
 dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.2-cfw-retro-go-1mb-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
 --title "G&W CFW + Retro-Go 1MB /// INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Roms en /home/$usuario/game-and-watch-retro-go/roms/" \
 --ok-label Apply \
 --cancel-label Exit \
---menu "Selecciona con las flechas la opcion deseada:" 12 140 15 \
+--menu "
+Usuario actual: $usuario
+Consola seleccionada: $consola
+Opcion caratulas: $caratula (0=NO y 1=SI)
+Roms: /home/$usuario/game-and-watch-retro-go/roms/
+
+Selecciona con las flechas la opcion deseada:" 0 0 0 \
    1 "CFW con los parametros para 1MB" \
    2 "Compilar Retro-Go con los parametros para 1MB" \
    3 "Flashear Retro-Go con los parametros para 1MB" \

--- a/scene/2.2.2-cfw-retro-go-1mb-mario.sh
+++ b/scene/2.2.2-cfw-retro-go-1mb-mario.sh
@@ -4,7 +4,7 @@
 INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="mario"
-proc="6"
+proc="4"
 caratula="0"
 
 dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.2-cfw-retro-go-1mb-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \

--- a/scene/2.2.2-cfw-retro-go-4mb-zelda.sh
+++ b/scene/2.2.2-cfw-retro-go-4mb-zelda.sh
@@ -4,7 +4,7 @@
 INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="zelda"
-proc="2"
+proc="4"
 caratula="0"
 
 dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.2-cfw-retro-go-4mb-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
@@ -14,7 +14,8 @@ dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO
 --menu "Selecciona con las flechas la opcion deseada:" 12 140 15 \
    1 "CFW con los parametros para 4MB" \
    2 "Compilar Retro-Go con los parametros para 4MB" \
-   3 "Flashear Retro-Go con los parametros para 4MB" 2>"${INPUT}"
+   3 "Flashear Retro-Go con los parametros para 4MB" \
+   4 "Descarga y restauracion de saves-states con parametros 4MB"   2>"${INPUT}"
 menuitem=$(<"${INPUT}")
 case $menuitem in
   1)clear
@@ -128,5 +129,8 @@ case $menuitem in
     fi
     ./scene/2.2.2-cfw-retro-go-4mb-$consola.sh
     clear;;
+    4)clear
+    ./scene/2.2.2-save-state-$consola.sh
+	clear;;
 esac
 clear

--- a/scene/2.2.2-cfw-retro-go-4mb-zelda.sh
+++ b/scene/2.2.2-cfw-retro-go-4mb-zelda.sh
@@ -55,7 +55,7 @@ case $menuitem in
                 cd /home/$usuario/gameandwatch/game-and-watch-patch
                 make clean
                 #make PATCH_PARAMS="--internal-only" flash_patched_int
-                make PATCH_PARAMS="--device=zelda" flash_patched_int
+                make PATCH_PARAMS="--device=$consola" flash_patched_int
                 cd -
                 echo " "
                 echo " "
@@ -88,7 +88,7 @@ case $menuitem in
         clear
         cd /home/$usuario/gameandwatch/game-and-watch-retro-go
         make clean
-        make -j$proc COMPRESS=lzma INTFLASH_BANK=2 EXTFLASH_SIZE=1802240 EXTFLASH_OFFSET=851968 GNW_TARGET=zelda EXTENDED=1 COVERFLOW=$caratula
+        make -j$proc COMPRESS=lzma INTFLASH_BANK=2 EXTFLASH_SIZE=1802240 EXTFLASH_OFFSET=851968 GNW_TARGET=$consola EXTENDED=1 COVERFLOW=$caratula
         cd -
         echo " "
         echo " "
@@ -122,7 +122,7 @@ case $menuitem in
         read -n 1 -s -r -p ""
         cd /home/$usuario/gameandwatch/game-and-watch-retro-go
         #make clean
-        make -j$proc COMPRESS=lzma INTFLASH_BANK=2 EXTFLASH_SIZE=1802240 EXTFLASH_OFFSET=851968 GNW_TARGET=zelda EXTENDED=1 COVERFLOW=$caratula flash
+        make -j$proc COMPRESS=lzma INTFLASH_BANK=2 EXTFLASH_SIZE=1802240 EXTFLASH_OFFSET=851968 GNW_TARGET=$consola EXTENDED=1 COVERFLOW=$caratula flash
         cd -
         read -n 1 -s -r -p "Presiona cualquier tecla para continuar"
         dialog --backtitle "G&W $consola - Utilidades de flasheo" \

--- a/scene/2.2.2-cfw-retro-go-4mb-zelda.sh
+++ b/scene/2.2.2-cfw-retro-go-4mb-zelda.sh
@@ -55,7 +55,7 @@ case $menuitem in
                 cd /home/$usuario/gameandwatch/game-and-watch-patch
                 make clean
                 #make PATCH_PARAMS="--internal-only" flash_patched_int
-                make PATCH_PARAMS="--device=$consola" flash_patched_int
+                make PATCH_PARAMS="--device=$consola --extended --no-la --no-sleep-images --extended" flash
                 cd -
                 echo " "
                 echo " "

--- a/scene/2.2.2-cfw-retro-go-4mb-zelda.sh
+++ b/scene/2.2.2-cfw-retro-go-4mb-zelda.sh
@@ -11,7 +11,13 @@ dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO
 --title "G&W CFW + Retro-Go 4MB /// INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Roms en /home/$usuario/game-and-watch-retro-go/roms/" \
 --ok-label Apply \
 --cancel-label Exit \
---menu "Selecciona con las flechas la opcion deseada:" 12 140 15 \
+--menu "
+Usuario actual: $usuario
+Consola seleccionada: $consola
+Opcion caratulas: $caratula (0=NO y 1=SI)
+Roms: /home/$usuario/game-and-watch-retro-go/roms/
+
+Selecciona con las flechas la opcion deseada:" 0 0 0 \
    1 "CFW con los parametros para 4MB" \
    2 "Compilar Retro-Go con los parametros para 4MB" \
    3 "Flashear Retro-Go con los parametros para 4MB" \

--- a/scene/2.2.2-cfw-retro-go-4mb-zelda.sh
+++ b/scene/2.2.2-cfw-retro-go-4mb-zelda.sh
@@ -18,12 +18,17 @@ Opcion caratulas: $caratula (0=NO y 1=SI)
 Roms: /home/$usuario/game-and-watch-retro-go/roms/
 
 Selecciona con las flechas la opcion deseada:" 0 0 0 \
+   H "Herramientas y utilidades" \
    1 "CFW con los parametros para 4MB" \
    2 "Compilar Retro-Go con los parametros para 4MB" \
    3 "Flashear Retro-Go con los parametros para 4MB" \
    4 "Descarga y restauracion de saves-states con parametros 4MB"   2>"${INPUT}"
 menuitem=$(<"${INPUT}")
 case $menuitem in
+  H)clear
+    ./scene/2.2.H-opcion-herramientas.sh
+    ./scene/2.2.2-cfw-retro-go-4mb-$consola.sh
+    clear;;
   1)clear
     dialog --backtitle "G&W $consola - Utilidades de flasheo" \
     --title "Instalar Retro-Go en consola G&W $consola con 4MB" \

--- a/scene/2.2.2-cfw-retro-go-4mb-zelda.sh
+++ b/scene/2.2.2-cfw-retro-go-4mb-zelda.sh
@@ -131,6 +131,7 @@ case $menuitem in
     clear;;
     4)clear
     ./scene/2.2.2-save-state-$consola.sh
+    ./scene/2.2.2-cfw-retro-go-4mb-$consola.sh
 	clear;;
 esac
 clear

--- a/scene/2.2.2-cfw-retro-go-4mb-zelda.sh
+++ b/scene/2.2.2-cfw-retro-go-4mb-zelda.sh
@@ -5,7 +5,7 @@ INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="zelda"
 proc="4"
-caratula="0"
+caratula="1"
 
 dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.2-cfw-retro-go-4mb-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
 --title "G&W CFW + Retro-Go 4MB /// INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Roms en /home/$usuario/game-and-watch-retro-go/roms/" \

--- a/scene/2.2.2-cfw-retro-go-4mb-zelda.sh
+++ b/scene/2.2.2-cfw-retro-go-4mb-zelda.sh
@@ -49,7 +49,7 @@ case $menuitem in
                 cd /home/$usuario/gameandwatch/game-and-watch-patch
                 make clean
                 #make PATCH_PARAMS="--internal-only" flash_patched_int
-                make PATCH_PARAMS="--device=$consola --extended --no-la --no-sleep-images --extended" flash
+                make PATCH_PARAMS="--device=zelda" flash_patched_int
                 cd -
                 echo " "
                 echo " "

--- a/scene/2.2.2-cfw-retro-go-4mb-zelda.sh
+++ b/scene/2.2.2-cfw-retro-go-4mb-zelda.sh
@@ -5,7 +5,7 @@ INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="zelda"
 proc="4"
-caratula="1"
+caratula="0"
 
 dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.2-cfw-retro-go-4mb-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
 --title "G&W CFW + Retro-Go 4MB /// INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Roms en /home/$usuario/game-and-watch-retro-go/roms/" \

--- a/scene/2.2.2-save-state-mario.sh
+++ b/scene/2.2.2-save-state-mario.sh
@@ -4,7 +4,7 @@
 INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="mario"
-proc="4"
+proc="6"
 caratula="0"
 
 clear
@@ -27,7 +27,13 @@ dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO
        --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
        --ok-label Apply \
        --cancel-label Exit \
-       --menu "Selecciona con las flechas la opcion deseada:" 12 140 15 \
+       --menu "
+Usuario actual: $usuario
+Consola seleccionada: $consola
+Opcion caratulas: $caratula (0=NO y 1=SI)
+Save states: /home/$usuario/game-and-watch-retro-go/save_states/
+
+Selecciona con las flechas la opcion deseada:" 0 0 0 \
           1 "Hacer backup de los save states existentes que hay en la G&W con chip original de 1MB" \
           2 "Restaurar los save states desde el pc a la G&W con chip original de 1MB" \
           3 "Borrar los saves states existentes en la G&W con chip de original 1MB para dejarla limpia"   2>"${INPUT}"

--- a/scene/2.2.2-save-state-mario.sh
+++ b/scene/2.2.2-save-state-mario.sh
@@ -7,126 +7,106 @@ consola="mario"
 proc="4"
 caratula="1"
 
+clear
+dpkg -s libncurses5 > libncurses5.txt
+if grep "install ok installed" ./libncurses5.txt ; then
+        echo "Encontrado paquete libncurses5, se prosigue..."
+        sleep 0.5
+else
+        echo "No encontrado paquete dialog necesario, instalando..."
+        echo " "
+        sudo apt install -y libncurses5
+        echo " "
+        echo "Instalado!!"
+        sleep 0.5
+fi
+
 dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.2-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
---title "G&W CFW + Retro-Go 1MB /// INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Roms en /home/$usuario/game-and-watch-retro-go/roms/" \
---ok-label Apply \
---cancel-label Exit \
---menu "Selecciona con las flechas la opcion deseada:" 12 140 15 \
-   1 "prueba" \
-   2 "Compilar Retro-Go con los parametros para 1MB" \
-   3 "Flashear Retro-Go con los parametros para 1MB" 2>"${INPUT}"
+       --msgbox "G&W Utilidad para backup, resturacion y borrado de save states. Una vez descargados los save states estan ubicados en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" 0 0
+dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.2-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+       --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+       --ok-label Apply \
+       --cancel-label Exit \
+       --menu "Selecciona con las flechas la opcion deseada:" 12 140 15 \
+          1 "Hacer backup de los save states existentes que hay en la G&W con chip original de 1MB" \
+          2 "Restaurar los save states desde el pc a la G&W con chip original de 1MB" \
+          3 "Borrar los saves states existentes en la G&W con chip de original 1MB para dejarla limpia"   2>"${INPUT}"
 menuitem=$(<"${INPUT}")
 case $menuitem in
   1)clear
-    dialog --backtitle "G&W $consola - Utilidades de flasheo" \
-    --title "Instalar Retro-Go en consola G&W $consola con 1MB" \
-    --yesno "Se recomienda realizar el proceso con la batería cargada al 100% para evitar problemas. Este proceso es solamente para una consola con el chip de 1MB instalado (chip original).\n\n¡¡¡ATENCION!!!\nSI SE TIENE DIFERENTE CANTIDAD DE MEMORIA CANCELAR EL PROCESO y una vez vuelto al menu seleccionar el correcto.\n\nSe flasheara un custom firmware que consta del menu original de la consola ademas del emulador Retro-Go. El emulador aparecera al realizar el combo de botones \"LEFT\" + \"GAME\". Las roms que existan en /home/$usuario/game-and-watch-retro-go/roms/ tambien se subiran a la consola ¿Deseas continuar?" 0 0
+    dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.2-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+           --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+           --yesno "¡¡¡ATENCION!!! El proceso de BACKUP de los save states puede llegar a tardar varios minutos dependiendo de la cantidad de roms que haya en la G&W y pararlo puede ocasionar errores. ¿Deseas continuar?" 0 0
     ans=$?
     if [ $ans -eq 0 ]; then
         clear
-        if [ -f /home/$usuario/gameandwatch/game-and-watch-backup/backups/flash_backup_$consola.bin ]; then
-            echo "flash_backup_$consola.bin encontrado"
-            sleep 0.5
-            if [ -f /home/$usuario/gameandwatch/game-and-watch-backup/backups/internal_flash_backup_$consola.bin ]; then
-                echo "internal_flash_backup_$consola.bin encontrado"
-                sleep 0.5
-                cp /home/$usuario/gameandwatch/game-and-watch-backup/backups/flash_backup_$consola.bin /home/$usuario/gameandwatch/game-and-watch-patch
-                cp /home/$usuario/gameandwatch/game-and-watch-backup/backups/internal_flash_backup_$consola.bin /home/$usuario/gameandwatch/game-and-watch-patch
-                echo " "
-                echo "Se han copiado los archivos de la flash interna y externa"
-                echo " "
-                echo " "
-                echo "Proceso 1/2 concluido."
-                echo " "
-                echo -e "\e[1;34mSi ya has ejecutado esta opcion anteriormente y algo ha salido mal desmonta la consola y vuelve a ejecutar esta\e[0m"
-                echo -e "\e[1;34mopcion y, al llegar a este punto, desconecta la bateria y vuelve a conectarla antes de realizar lo siguiente.\e[0m"
-                echo " "
-                echo " "
-                echo -e "\e[1;31mPulsa y manten pulsado el boton de encendido y justo despues pulsa cualquier tecla para continuar...\e[0m"
-                read -n 1 -s -r -p ""
-                clear
-                cd /home/$usuario/gameandwatch/game-and-watch-patch
-                make clean
-                #make PATCH_PARAMS="--internal-only" flash_patched_int
-                make PATCH_PARAMS="--device=$consola --internal-only" flash_patched
-                cd -
-                echo " "
-                echo " "
-                echo "Proceso 2/2 concluido."
-                read -n 1 -s -r -p "Presiona cualquier tecla para continuar"
-            else
-                echo "No se ha encontrado internal_flash_backup_$consola.bin, cancelando..."
-                sleep 2
-            fi
-        else
-            echo "No se ha encontrado flash_backup_$consola.bin, cancelando..."
-            sleep 2
-        fi
-        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
-        --title "Instalar firmware original + Retro-Go  en consola con 1MB" \
-        --msgbox "Proceso realizado." 0 0
+        echo -e "\e[1;31mEnciende la consola y entra al menu Retro-Go con los botones LEFT+GAME y dejala esperando en el listado de las roms.\e[0m"
+        echo ""
+        echo -e "\e[1;31mPara continuar con el proceso pulsa cualquier tecla...\e[0m"
+        read -n 1 -s -r -p ""
+        cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
+        make -j$proc COMPRESS=lzma INTFLASH_BANK=2 COVERFLOW=$caratula flash_saves_backup
+        cd -
+        #sleep 5
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.2-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso realizado. Save states descargados en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" 0 0
     else
-            dialog --backtitle "G&W $consola - Utilidades de flasheo" \
-            --title "Instalar firmware original + Retro-Go  en consola con 1MB" \
-            --msgbox "Proceso cancelado." 0 0
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.2-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso cancelado." 0 0
     fi
-    ./scene/2.2.2-cfw-retro-go-1mb-$consola.sh
+    ./scene/2.2.2-save-state-$consola.sh
     clear;;
   2)clear
-    dialog --backtitle "G&W $consola - Utilidades de flasheo" \
-    --title "Compilar Retro-Go" \
-    --yesno "Se procedera a compilar RetroGo y se incluiran las roms que existan en /home/$usuario/game-and-watch-retro-go/roms/. ¿Deseas continuar?" 0 0
+    dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.2-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+           --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+           --yesno "¡¡¡ATENCION!!! El proceso RESTAURACION de los save states puede llegar a tardar varios minutos dependiendo de la cantidad de roms que haya en la G&W y pararlo puede ocasionar errores. ¿Deseas continuar?" 0 0
     ans=$?
     if [ $ans -eq 0 ]; then
         clear
-        cd /home/$usuario/gameandwatch/game-and-watch-retro-go
-        make clean
-        make -j$proc COMPRESS=lzma INTFLASH_BANK=2 COVERFLOW=$caratula
-		cd -
-        echo " "
-        echo " "
-        read -n 1 -s -r -p "Proceso concluido. Presiona cualquier tecla para continuar."
-        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
-        --title "Compilar Retro-Go" \
-        --msgbox "Proceso realizado." 0 0
+        echo -e "\e[1;31mEnciende la consola y entra al menu Retro-Go con los botones LEFT+GAME y dejala esperando en el listado de las roms.\e[0m"
+        echo ""
+        echo -e "\e[1;31mPara continuar con el proceso pulsa cualquier tecla...\e[0m"
+        read -n 1 -s -r -p ""
+        cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
+        make -j$proc COMPRESS=lzma INTFLASH_BANK=2 COVERFLOW=$caratula flash_saves_restore
+        cd -
+        #sleep 5
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.2-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso realizado." 0 0
     else
-        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
-        --title "Compilar Retro-Go" \
-        --msgbox "Proceso cancelado." 0 0
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.2-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso cancelado." 0 0
     fi
-    ./scene/2.2.2-cfw-retro-go-1mb-$consola.sh
+    ./scene/2.2.2-save-state-$consola.sh
     clear;;
   3)clear
-    dialog --backtitle "G&W $consola - Utilidades de flasheo" \
-    --title "Compilar Retro-Go" \
-    --yesno "Se recomienda realizar el proceso con la batería cargada al 100% para evitar problemas. Se flasheara solamente el emulador Retro-Go por lo que no tendremos el menu original. Las roms que existan en /home/$usuario/game-and-watch-retro-go/roms/ tambien se subiran a la consola." 0 0
+    dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.2-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+           --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+           --yesno "¡¡¡ATENCION!!! El proceso BORRAR los save states puede llegar a tardar varios minutos dependiendo de la cantidad de roms que haya en la G&W y pararlo puede ocasionar errores. ¿Deseas continuar?" 0 0
     ans=$?
     if [ $ans -eq 0 ]; then
         clear
-        echo " "
-        echo -e "\e[1;34mSi ya has ejecutado esta opcion anteriormente y algo ha salido mal desmonta la consola y vuelve a ejecutar esta\e[0m"
-        echo -e "\e[1;34mopcion y, al llegar a este punto, desconecta la bateria y vuelve a conectarla antes de realizar lo siguiente.\e[0m"
-        echo " "
-        echo " "
-        echo -e "\e[0;32mSi durante el siguiente proceso nos dice que ha fallado el flasheo, que no puede conectar y nos pregunta si\e[0m"
-        echo -e "\e[0;32mvamos a hacer un power cycle (quitar bateria, reconectar y encender) pulsaremos el boton de encendido y lo \e[0m"
-        echo -e "\e[0;32mmantendremos pulsado unos segundos, le diremos que si con \"y\" (yes), entonces el proceso continuara.\e[0m"
-        echo -e "\e[1;31mPulsa y manten pulsado el boton de encendido y justo despues pulsa cualquier tecla para continuar...\nATENCION: No sueltes el boton al menos hasta que empiece a borrar la memoria externa (cuando pone \"Erasing xxxx bytes...\" en la pantalla)\e[0m"
+        echo -e "\e[1;31mEnciende la consola y entra al menu Retro-Go con los botones LEFT+GAME y dejala esperando en el listado de las roms.\e[0m"
+        echo ""
+        echo -e "\e[1;31mPara continuar con el proceso pulsa cualquier tecla...\e[0m"
         read -n 1 -s -r -p ""
-        cd /home/$usuario/gameandwatch/game-and-watch-retro-go
-        #make clean
-        make -j$proc COMPRESS=lzma INTFLASH_BANK=2 COVERFLOW=$caratula flash
+        cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
+        make -j$proc COMPRESS=lzma INTFLASH_BANK=2 COVERFLOW=$caratula flash_saves_erase
         cd -
-        read -n 1 -s -r -p "Presiona cualquier tecla para continuar"
-        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
-        --title "Instalar solo Retro-Go" \
-        --msgbox "Proceso realizado." 0 0
+        #sleep 5
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.2-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso realizado." 0 0
     else
-        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
-        --title "Instalar solo Retro-Go" \
-        --msgbox "Proceso cancelado." 0 0
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.2-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso cancelado." 0 0
     fi
-    ./scene/2.2.2-cfw-retro-go-1mb-$consola.sh
+    ./scene/2.2.2-save-state-$consola.sh
     clear;;
 esac
 clear

--- a/scene/2.2.2-save-state-mario.sh
+++ b/scene/2.2.2-save-state-mario.sh
@@ -4,7 +4,7 @@
 INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="mario"
-proc="6"
+proc="4"
 caratula="0"
 
 clear

--- a/scene/2.2.2-save-state-mario.sh
+++ b/scene/2.2.2-save-state-mario.sh
@@ -5,7 +5,7 @@ INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="mario"
 proc="4"
-caratula="1"
+caratula="0"
 
 clear
 dpkg -s libncurses5 > libncurses5.txt
@@ -47,7 +47,8 @@ case $menuitem in
         cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
         make -j$proc COMPRESS=lzma INTFLASH_BANK=2 GNW_TARGET=$consola COVERFLOW=$caratula flash_saves_backup
         cd -
-        #sleep 5
+        echo -e "\e[1;31mPulsa cualquier tecla para continuar...\e[0m"
+        read -n 1 -s -r -p ""
         dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.2-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
                --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
                --msgbox "Proceso realizado. Save states descargados en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" 0 0
@@ -72,7 +73,8 @@ case $menuitem in
         cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
         make -j$proc COMPRESS=lzma INTFLASH_BANK=2 GNW_TARGET=$consola COVERFLOW=$caratula flash_saves_restore
         cd -
-        #sleep 5
+        echo -e "\e[1;31mPulsa cualquier tecla para continuar...\e[0m"
+        read -n 1 -s -r -p ""
         dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.2-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
                --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
                --msgbox "Proceso realizado." 0 0
@@ -97,7 +99,8 @@ case $menuitem in
         cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
         make -j$proc COMPRESS=lzma INTFLASH_BANK=2 GNW_TARGET=$consola COVERFLOW=$caratula flash_saves_erase
         cd -
-        #sleep 5
+        echo -e "\e[1;31mPulsa cualquier tecla para continuar...\e[0m"
+        read -n 1 -s -r -p ""
         dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.2-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
                --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
                --msgbox "Proceso realizado." 0 0

--- a/scene/2.2.2-save-state-mario.sh
+++ b/scene/2.2.2-save-state-mario.sh
@@ -5,9 +5,9 @@ INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="mario"
 proc="4"
-caratula="0"
+caratula="1"
 
-dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.2-cfw-retro-go-1mb-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.2-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
 --title "G&W CFW + Retro-Go 1MB /// INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Roms en /home/$usuario/game-and-watch-retro-go/roms/" \
 --ok-label Apply \
 --cancel-label Exit \

--- a/scene/2.2.2-save-state-mario.sh
+++ b/scene/2.2.2-save-state-mario.sh
@@ -45,7 +45,7 @@ case $menuitem in
         echo -e "\e[1;31mPara continuar con el proceso pulsa cualquier tecla...\e[0m"
         read -n 1 -s -r -p ""
         cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
-        make -j$proc COMPRESS=lzma INTFLASH_BANK=2 COVERFLOW=$caratula flash_saves_backup
+        make -j$proc COMPRESS=lzma INTFLASH_BANK=2 GNW_TARGET=$consola COVERFLOW=$caratula flash_saves_backup
         cd -
         #sleep 5
         dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.2-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
@@ -70,7 +70,7 @@ case $menuitem in
         echo -e "\e[1;31mPara continuar con el proceso pulsa cualquier tecla...\e[0m"
         read -n 1 -s -r -p ""
         cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
-        make -j$proc COMPRESS=lzma INTFLASH_BANK=2 COVERFLOW=$caratula flash_saves_restore
+        make -j$proc COMPRESS=lzma INTFLASH_BANK=2 GNW_TARGET=$consola COVERFLOW=$caratula flash_saves_restore
         cd -
         #sleep 5
         dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.2-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
@@ -95,7 +95,7 @@ case $menuitem in
         echo -e "\e[1;31mPara continuar con el proceso pulsa cualquier tecla...\e[0m"
         read -n 1 -s -r -p ""
         cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
-        make -j$proc COMPRESS=lzma INTFLASH_BANK=2 COVERFLOW=$caratula flash_saves_erase
+        make -j$proc COMPRESS=lzma INTFLASH_BANK=2 GNW_TARGET=$consola COVERFLOW=$caratula flash_saves_erase
         cd -
         #sleep 5
         dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.2-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \

--- a/scene/2.2.2-save-state-mario.sh
+++ b/scene/2.2.2-save-state-mario.sh
@@ -12,7 +12,7 @@ dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO
 --ok-label Apply \
 --cancel-label Exit \
 --menu "Selecciona con las flechas la opcion deseada:" 12 140 15 \
-   1 "CFW con los parametros para 1MB" \
+   1 "prueba" \
    2 "Compilar Retro-Go con los parametros para 1MB" \
    3 "Flashear Retro-Go con los parametros para 1MB" 2>"${INPUT}"
 menuitem=$(<"${INPUT}")

--- a/scene/2.2.2-save-state-mario.sh
+++ b/scene/2.2.2-save-state-mario.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+#By julenvitoria
+
+INPUT=/tmp/$MENU.sh.$$
+usuario="kde"
+consola="mario"
+proc="4"
+caratula="0"
+
+dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.2-cfw-retro-go-1mb-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+--title "G&W CFW + Retro-Go 1MB /// INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Roms en /home/$usuario/game-and-watch-retro-go/roms/" \
+--ok-label Apply \
+--cancel-label Exit \
+--menu "Selecciona con las flechas la opcion deseada:" 12 140 15 \
+   1 "CFW con los parametros para 1MB" \
+   2 "Compilar Retro-Go con los parametros para 1MB" \
+   3 "Flashear Retro-Go con los parametros para 1MB" 2>"${INPUT}"
+menuitem=$(<"${INPUT}")
+case $menuitem in
+  1)clear
+    dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+    --title "Instalar Retro-Go en consola G&W $consola con 1MB" \
+    --yesno "Se recomienda realizar el proceso con la batería cargada al 100% para evitar problemas. Este proceso es solamente para una consola con el chip de 1MB instalado (chip original).\n\n¡¡¡ATENCION!!!\nSI SE TIENE DIFERENTE CANTIDAD DE MEMORIA CANCELAR EL PROCESO y una vez vuelto al menu seleccionar el correcto.\n\nSe flasheara un custom firmware que consta del menu original de la consola ademas del emulador Retro-Go. El emulador aparecera al realizar el combo de botones \"LEFT\" + \"GAME\". Las roms que existan en /home/$usuario/game-and-watch-retro-go/roms/ tambien se subiran a la consola ¿Deseas continuar?" 0 0
+    ans=$?
+    if [ $ans -eq 0 ]; then
+        clear
+        if [ -f /home/$usuario/gameandwatch/game-and-watch-backup/backups/flash_backup_$consola.bin ]; then
+            echo "flash_backup_$consola.bin encontrado"
+            sleep 0.5
+            if [ -f /home/$usuario/gameandwatch/game-and-watch-backup/backups/internal_flash_backup_$consola.bin ]; then
+                echo "internal_flash_backup_$consola.bin encontrado"
+                sleep 0.5
+                cp /home/$usuario/gameandwatch/game-and-watch-backup/backups/flash_backup_$consola.bin /home/$usuario/gameandwatch/game-and-watch-patch
+                cp /home/$usuario/gameandwatch/game-and-watch-backup/backups/internal_flash_backup_$consola.bin /home/$usuario/gameandwatch/game-and-watch-patch
+                echo " "
+                echo "Se han copiado los archivos de la flash interna y externa"
+                echo " "
+                echo " "
+                echo "Proceso 1/2 concluido."
+                echo " "
+                echo -e "\e[1;34mSi ya has ejecutado esta opcion anteriormente y algo ha salido mal desmonta la consola y vuelve a ejecutar esta\e[0m"
+                echo -e "\e[1;34mopcion y, al llegar a este punto, desconecta la bateria y vuelve a conectarla antes de realizar lo siguiente.\e[0m"
+                echo " "
+                echo " "
+                echo -e "\e[1;31mPulsa y manten pulsado el boton de encendido y justo despues pulsa cualquier tecla para continuar...\e[0m"
+                read -n 1 -s -r -p ""
+                clear
+                cd /home/$usuario/gameandwatch/game-and-watch-patch
+                make clean
+                #make PATCH_PARAMS="--internal-only" flash_patched_int
+                make PATCH_PARAMS="--device=$consola --internal-only" flash_patched
+                cd -
+                echo " "
+                echo " "
+                echo "Proceso 2/2 concluido."
+                read -n 1 -s -r -p "Presiona cualquier tecla para continuar"
+            else
+                echo "No se ha encontrado internal_flash_backup_$consola.bin, cancelando..."
+                sleep 2
+            fi
+        else
+            echo "No se ha encontrado flash_backup_$consola.bin, cancelando..."
+            sleep 2
+        fi
+        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+        --title "Instalar firmware original + Retro-Go  en consola con 1MB" \
+        --msgbox "Proceso realizado." 0 0
+    else
+            dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+            --title "Instalar firmware original + Retro-Go  en consola con 1MB" \
+            --msgbox "Proceso cancelado." 0 0
+    fi
+    ./scene/2.2.2-cfw-retro-go-1mb-$consola.sh
+    clear;;
+  2)clear
+    dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+    --title "Compilar Retro-Go" \
+    --yesno "Se procedera a compilar RetroGo y se incluiran las roms que existan en /home/$usuario/game-and-watch-retro-go/roms/. ¿Deseas continuar?" 0 0
+    ans=$?
+    if [ $ans -eq 0 ]; then
+        clear
+        cd /home/$usuario/gameandwatch/game-and-watch-retro-go
+        make clean
+        make -j$proc COMPRESS=lzma INTFLASH_BANK=2 COVERFLOW=$caratula
+		cd -
+        echo " "
+        echo " "
+        read -n 1 -s -r -p "Proceso concluido. Presiona cualquier tecla para continuar."
+        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+        --title "Compilar Retro-Go" \
+        --msgbox "Proceso realizado." 0 0
+    else
+        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+        --title "Compilar Retro-Go" \
+        --msgbox "Proceso cancelado." 0 0
+    fi
+    ./scene/2.2.2-cfw-retro-go-1mb-$consola.sh
+    clear;;
+  3)clear
+    dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+    --title "Compilar Retro-Go" \
+    --yesno "Se recomienda realizar el proceso con la batería cargada al 100% para evitar problemas. Se flasheara solamente el emulador Retro-Go por lo que no tendremos el menu original. Las roms que existan en /home/$usuario/game-and-watch-retro-go/roms/ tambien se subiran a la consola." 0 0
+    ans=$?
+    if [ $ans -eq 0 ]; then
+        clear
+        echo " "
+        echo -e "\e[1;34mSi ya has ejecutado esta opcion anteriormente y algo ha salido mal desmonta la consola y vuelve a ejecutar esta\e[0m"
+        echo -e "\e[1;34mopcion y, al llegar a este punto, desconecta la bateria y vuelve a conectarla antes de realizar lo siguiente.\e[0m"
+        echo " "
+        echo " "
+        echo -e "\e[0;32mSi durante el siguiente proceso nos dice que ha fallado el flasheo, que no puede conectar y nos pregunta si\e[0m"
+        echo -e "\e[0;32mvamos a hacer un power cycle (quitar bateria, reconectar y encender) pulsaremos el boton de encendido y lo \e[0m"
+        echo -e "\e[0;32mmantendremos pulsado unos segundos, le diremos que si con \"y\" (yes), entonces el proceso continuara.\e[0m"
+        echo -e "\e[1;31mPulsa y manten pulsado el boton de encendido y justo despues pulsa cualquier tecla para continuar...\nATENCION: No sueltes el boton al menos hasta que empiece a borrar la memoria externa (cuando pone \"Erasing xxxx bytes...\" en la pantalla)\e[0m"
+        read -n 1 -s -r -p ""
+        cd /home/$usuario/gameandwatch/game-and-watch-retro-go
+        #make clean
+        make -j$proc COMPRESS=lzma INTFLASH_BANK=2 COVERFLOW=$caratula flash
+        cd -
+        read -n 1 -s -r -p "Presiona cualquier tecla para continuar"
+        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+        --title "Instalar solo Retro-Go" \
+        --msgbox "Proceso realizado." 0 0
+    else
+        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+        --title "Instalar solo Retro-Go" \
+        --msgbox "Proceso cancelado." 0 0
+    fi
+    ./scene/2.2.2-cfw-retro-go-1mb-$consola.sh
+    clear;;
+esac
+clear

--- a/scene/2.2.2-save-state-zelda.sh
+++ b/scene/2.2.2-save-state-zelda.sh
@@ -5,7 +5,7 @@ INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="zelda"
 proc="4"
-caratula="1"
+caratula="0"
 
 clear
 dpkg -s libncurses5 > libncurses5.txt
@@ -28,9 +28,9 @@ dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO
        --ok-label Apply \
        --cancel-label Exit \
        --menu "Selecciona con las flechas la opcion deseada:" 12 140 15 \
-          1 "Hacer backup de los save states existentes que hay en la G&W con chip original de 1MB" \
-          2 "Restaurar los save states desde el pc a la G&W con chip original de 1MB" \
-          3 "Borrar los saves states existentes en la G&W con chip de original 1MB para dejarla limpia"   2>"${INPUT}"
+          1 "Hacer backup de los save states existentes que hay en la G&W con chip original de 4MB" \
+          2 "Restaurar los save states desde el pc a la G&W con chip original de 4MB" \
+          3 "Borrar los saves states existentes en la G&W con chip de original 4MB para dejarla limpia"   2>"${INPUT}"
 menuitem=$(<"${INPUT}")
 case $menuitem in
   1)clear
@@ -47,7 +47,8 @@ case $menuitem in
         cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
         make -j$proc COMPRESS=lzma INTFLASH_BANK=2 EXTFLASH_SIZE=1802240 EXTFLASH_OFFSET=851968 GNW_TARGET=zelda EXTENDED=1 COVERFLOW=$caratula flash_saves_backup
         cd -
-        #sleep 5
+        echo -e "\e[1;31mPulsa cualquier tecla para continuar...\e[0m"
+        read -n 1 -s -r -p ""
         dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.2-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
                --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
                --msgbox "Proceso realizado. Save states descargados en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" 0 0
@@ -72,7 +73,8 @@ case $menuitem in
         cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
         make -j$proc COMPRESS=lzma INTFLASH_BANK=2 EXTFLASH_SIZE=1802240 EXTFLASH_OFFSET=851968 GNW_TARGET=zelda EXTENDED=1 COVERFLOW=$caratula flash_saves_restore
         cd -
-        #sleep 5
+        echo -e "\e[1;31mPulsa cualquier tecla para continuar...\e[0m"
+        read -n 1 -s -r -p ""
         dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.2-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
                --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
                --msgbox "Proceso realizado." 0 0
@@ -97,7 +99,8 @@ case $menuitem in
         cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
         make -j$proc COMPRESS=lzma INTFLASH_BANK=2 EXTFLASH_SIZE=1802240 EXTFLASH_OFFSET=851968 GNW_TARGET=zelda EXTENDED=1 COVERFLOW=$caratula flash_saves_erase
         cd -
-        #sleep 5
+        echo -e "\e[1;31mPulsa cualquier tecla para continuar...\e[0m"
+        read -n 1 -s -r -p ""
         dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.2-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
                --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
                --msgbox "Proceso realizado." 0 0

--- a/scene/2.2.2-save-state-zelda.sh
+++ b/scene/2.2.2-save-state-zelda.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+#By julenvitoria
+
+INPUT=/tmp/$MENU.sh.$$
+usuario="kde"
+consola="zelda"
+proc="2"
+caratula="0"
+
+dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.2-cfw-retro-go-4mb-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+--title "G&W CFW + Retro-Go 4MB /// INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Roms en /home/$usuario/game-and-watch-retro-go/roms/" \
+--ok-label Apply \
+--cancel-label Exit \
+--menu "Selecciona con las flechas la opcion deseada:" 12 140 15 \
+   1 "CFW con los parametros para 4MB" \
+   2 "Compilar Retro-Go con los parametros para 4MB" \
+   3 "Flashear Retro-Go con los parametros para 4MB" 2>"${INPUT}"
+menuitem=$(<"${INPUT}")
+case $menuitem in
+  1)clear
+    dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+    --title "Instalar Retro-Go en consola G&W $consola con 4MB" \
+    --yesno "Se recomienda realizar el proceso con la batería cargada al 100% para evitar problemas. Este proceso es solamente para una consola con el chip de 4MB instalado (chip original).\n\n¡¡¡ATENCION!!!\nSI SE TIENE DIFERENTE CANTIDAD DE MEMORIA CANCELAR EL PROCESO y una vez vuelto al menu seleccionar el correcto.\n\nSe flasheara un custom firmware que consta del menu original de la consola ademas del emulador Retro-Go. El emulador aparecera al realizar el combo de botones \"LEFT\" + \"GAME\". Las roms que existan en /home/$usuario/game-and-watch-retro-go/roms/ tambien se subiran a la consola ¿Deseas continuar?" 0 0
+    ans=$?
+    if [ $ans -eq 0 ]; then
+        clear
+        if [ -f /home/$usuario/gameandwatch/game-and-watch-backup/backups/flash_backup_$consola.bin ]; then
+            echo "flash_backup_$consola.bin encontrado"
+            sleep 0.5
+            if [ -f /home/$usuario/gameandwatch/game-and-watch-backup/backups/internal_flash_backup_$consola.bin ]; then
+                echo "internal_flash_backup_$consola.bin encontrado"
+                sleep 0.5
+                cp /home/$usuario/gameandwatch/game-and-watch-backup/backups/flash_backup_$consola.bin /home/$usuario/gameandwatch/game-and-watch-patch
+                cp /home/$usuario/gameandwatch/game-and-watch-backup/backups/internal_flash_backup_$consola.bin /home/$usuario/gameandwatch/game-and-watch-patch
+                echo " "
+                echo "Se han copiado los archivos de la flash interna y externa"
+                echo " "
+                echo " "
+                echo "Proceso 1/2 concluido."
+                echo " "
+                echo -e "\e[1;34mSi ya has ejecutado esta opcion anteriormente y algo ha salido mal desmonta la consola y vuelve a ejecutar esta\e[0m"
+                echo -e "\e[1;34mopcion y, al llegar a este punto, desconecta la bateria y vuelve a conectarla antes de realizar lo siguiente.\e[0m"
+                echo " "
+                echo " "
+                echo -e "\e[1;31mPulsa y manten pulsado el boton de encendido y justo despues pulsa cualquier tecla para continuar...\e[0m"
+                read -n 1 -s -r -p ""
+                clear
+                cd /home/$usuario/gameandwatch/game-and-watch-patch
+                make clean
+                #make PATCH_PARAMS="--internal-only" flash_patched_int
+                make PATCH_PARAMS="--device=$consola --extended --no-la --no-sleep-images --extended" flash
+                cd -
+                echo " "
+                echo " "
+                echo "Proceso 2/2 concluido."
+                read -n 1 -s -r -p "Presiona cualquier tecla para continuar"
+            else
+                echo "No se ha encontrado internal_flash_backup_$consola.bin, cancelando..."
+                sleep 2
+            fi
+        else
+            echo "No se ha encontrado flash_backup_$consola.bin, cancelando..."
+            sleep 2
+        fi
+        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+        --title "Instalar firmware original + Retro-Go  en consola con 4MB" \
+        --msgbox "Proceso realizado." 0 0
+    else
+            dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+            --title "Instalar firmware original + Retro-Go  en consola con 4MB" \
+            --msgbox "Proceso cancelado." 0 0
+    fi
+    ./scene/2.2.2-cfw-retro-go-4mb-$consola.sh
+    clear;;
+  2)clear
+    dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+    --title "Compilar Retro-Go" \
+    --yesno "Se procedera a compilar RetroGo y se incluiran las roms que existan en /home/$usuario/game-and-watch-retro-go/roms/. ¿Deseas continuar?" 0 0
+    ans=$?
+    if [ $ans -eq 0 ]; then
+        clear
+        cd /home/$usuario/gameandwatch/game-and-watch-retro-go
+        make clean
+        make -j$proc COMPRESS=lzma INTFLASH_BANK=2 EXTFLASH_SIZE=1802240 EXTFLASH_OFFSET=851968 GNW_TARGET=zelda EXTENDED=1 COVERFLOW=$caratula
+        cd -
+        echo " "
+        echo " "
+        read -n 1 -s -r -p "Proceso concluido. Presiona cualquier tecla para continuar."
+        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+        --title "Compilar Retro-Go" \
+        --msgbox "Proceso realizado." 0 0
+    else
+        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+        --title "Compilar Retro-Go" \
+        --msgbox "Proceso cancelado." 0 0
+    fi
+    ./scene/2.2.2-cfw-retro-go-4mb-$consola.sh
+    clear;;
+  3)clear
+    dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+    --title "Compilar Retro-Go" \
+    --yesno "Se recomienda realizar el proceso con la batería cargada al 100% para evitar problemas. Se flasheara solamente el emulador Retro-Go por lo que no tendremos el menu original. Las roms que existan en /home/$usuario/game-and-watch-retro-go/roms/ tambien se subiran a la consola." 0 0
+    ans=$?
+    if [ $ans -eq 0 ]; then
+        clear
+        echo " "
+        echo -e "\e[1;34mSi ya has ejecutado esta opcion anteriormente y algo ha salido mal desmonta la consola y vuelve a ejecutar esta\e[0m"
+        echo -e "\e[1;34mopcion y, al llegar a este punto, desconecta la bateria y vuelve a conectarla antes de realizar lo siguiente.\e[0m"
+        echo " "
+        echo " "
+        echo -e "\e[0;32mSi durante el siguiente proceso nos dice que ha fallado el flasheo, que no puede conectar y nos pregunta si\e[0m"
+        echo -e "\e[0;32mvamos a hacer un power cycle (quitar bateria, reconectar y encender) pulsaremos el boton de encendido y lo \e[0m"
+        echo -e "\e[0;32mmantendremos pulsado unos segundos, le diremos que si con \"y\" (yes), entonces el proceso continuara.\e[0m"
+        echo -e "\e[1;31mPulsa y manten pulsado el boton de encendido y justo despues pulsa cualquier tecla para continuar...\nATENCION: No sueltes el boton al menos hasta que empiece a borrar la memoria externa (cuando pone \"Erasing xxxx bytes...\" en la pantalla)\e[0m"
+        read -n 1 -s -r -p ""
+        cd /home/$usuario/gameandwatch/game-and-watch-retro-go
+        #make clean
+        make -j$proc COMPRESS=lzma INTFLASH_BANK=2 EXTFLASH_SIZE=1802240 EXTFLASH_OFFSET=851968 GNW_TARGET=zelda EXTENDED=1 COVERFLOW=$caratula flash
+        cd -
+        read -n 1 -s -r -p "Presiona cualquier tecla para continuar"
+        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+        --title "Instalar solo Retro-Go" \
+        --msgbox "Proceso realizado." 0 0
+    else
+        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+        --title "Instalar solo Retro-Go" \
+        --msgbox "Proceso cancelado." 0 0
+    fi
+    ./scene/2.2.2-cfw-retro-go-4mb-$consola.sh
+    clear;;
+esac
+clear

--- a/scene/2.2.2-save-state-zelda.sh
+++ b/scene/2.2.2-save-state-zelda.sh
@@ -4,7 +4,7 @@
 INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="zelda"
-proc="4"
+proc="6"
 caratula="0"
 
 clear
@@ -27,7 +27,13 @@ dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO
        --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
        --ok-label Apply \
        --cancel-label Exit \
-       --menu "Selecciona con las flechas la opcion deseada:" 12 140 15 \
+       --menu "
+Usuario actual: $usuario
+Consola seleccionada: $consola
+Opcion caratulas: $caratula (0=NO y 1=SI)
+Save states: /home/$usuario/game-and-watch-retro-go/save_states/
+
+Selecciona con las flechas la opcion deseada:" 0 0 0 \
           1 "Hacer backup de los save states existentes que hay en la G&W con chip original de 4MB" \
           2 "Restaurar los save states desde el pc a la G&W con chip original de 4MB" \
           3 "Borrar los saves states existentes en la G&W con chip de original 4MB para dejarla limpia"   2>"${INPUT}"

--- a/scene/2.2.2-save-state-zelda.sh
+++ b/scene/2.2.2-save-state-zelda.sh
@@ -4,7 +4,7 @@
 INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="zelda"
-proc="6"
+proc="4"
 caratula="0"
 
 clear

--- a/scene/2.2.2-save-state-zelda.sh
+++ b/scene/2.2.2-save-state-zelda.sh
@@ -4,7 +4,7 @@
 INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="zelda"
-proc="2"
+proc="4"
 caratula="0"
 
 dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.2-cfw-retro-go-4mb-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
@@ -12,7 +12,7 @@ dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO
 --ok-label Apply \
 --cancel-label Exit \
 --menu "Selecciona con las flechas la opcion deseada:" 12 140 15 \
-   1 "CFW con los parametros para 4MB" \
+   1 "prueba" \
    2 "Compilar Retro-Go con los parametros para 4MB" \
    3 "Flashear Retro-Go con los parametros para 4MB" 2>"${INPUT}"
 menuitem=$(<"${INPUT}")

--- a/scene/2.2.2-save-state-zelda.sh
+++ b/scene/2.2.2-save-state-zelda.sh
@@ -7,126 +7,106 @@ consola="zelda"
 proc="4"
 caratula="1"
 
+clear
+dpkg -s libncurses5 > libncurses5.txt
+if grep "install ok installed" ./libncurses5.txt ; then
+        echo "Encontrado paquete libncurses5, se prosigue..."
+        sleep 0.5
+else
+        echo "No encontrado paquete dialog necesario, instalando..."
+        echo " "
+        sudo apt install -y libncurses5
+        echo " "
+        echo "Instalado!!"
+        sleep 0.5
+fi
+
 dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.2-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
---title "G&W CFW + Retro-Go 4MB /// INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Roms en /home/$usuario/game-and-watch-retro-go/roms/" \
---ok-label Apply \
---cancel-label Exit \
---menu "Selecciona con las flechas la opcion deseada:" 12 140 15 \
-   1 "prueba" \
-   2 "Compilar Retro-Go con los parametros para 4MB" \
-   3 "Flashear Retro-Go con los parametros para 4MB" 2>"${INPUT}"
+       --msgbox "G&W Utilidad para backup, resturacion y borrado de save states. Una vez descargados los save states estan ubicados en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" 0 0
+dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.2-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+       --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+       --ok-label Apply \
+       --cancel-label Exit \
+       --menu "Selecciona con las flechas la opcion deseada:" 12 140 15 \
+          1 "Hacer backup de los save states existentes que hay en la G&W con chip original de 1MB" \
+          2 "Restaurar los save states desde el pc a la G&W con chip original de 1MB" \
+          3 "Borrar los saves states existentes en la G&W con chip de original 1MB para dejarla limpia"   2>"${INPUT}"
 menuitem=$(<"${INPUT}")
 case $menuitem in
   1)clear
-    dialog --backtitle "G&W $consola - Utilidades de flasheo" \
-    --title "Instalar Retro-Go en consola G&W $consola con 4MB" \
-    --yesno "Se recomienda realizar el proceso con la batería cargada al 100% para evitar problemas. Este proceso es solamente para una consola con el chip de 4MB instalado (chip original).\n\n¡¡¡ATENCION!!!\nSI SE TIENE DIFERENTE CANTIDAD DE MEMORIA CANCELAR EL PROCESO y una vez vuelto al menu seleccionar el correcto.\n\nSe flasheara un custom firmware que consta del menu original de la consola ademas del emulador Retro-Go. El emulador aparecera al realizar el combo de botones \"LEFT\" + \"GAME\". Las roms que existan en /home/$usuario/game-and-watch-retro-go/roms/ tambien se subiran a la consola ¿Deseas continuar?" 0 0
+    dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.2-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+           --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+           --yesno "¡¡¡ATENCION!!! El proceso de BACKUP de los save states puede llegar a tardar varios minutos dependiendo de la cantidad de roms que haya en la G&W y pararlo puede ocasionar errores. ¿Deseas continuar?" 0 0
     ans=$?
     if [ $ans -eq 0 ]; then
         clear
-        if [ -f /home/$usuario/gameandwatch/game-and-watch-backup/backups/flash_backup_$consola.bin ]; then
-            echo "flash_backup_$consola.bin encontrado"
-            sleep 0.5
-            if [ -f /home/$usuario/gameandwatch/game-and-watch-backup/backups/internal_flash_backup_$consola.bin ]; then
-                echo "internal_flash_backup_$consola.bin encontrado"
-                sleep 0.5
-                cp /home/$usuario/gameandwatch/game-and-watch-backup/backups/flash_backup_$consola.bin /home/$usuario/gameandwatch/game-and-watch-patch
-                cp /home/$usuario/gameandwatch/game-and-watch-backup/backups/internal_flash_backup_$consola.bin /home/$usuario/gameandwatch/game-and-watch-patch
-                echo " "
-                echo "Se han copiado los archivos de la flash interna y externa"
-                echo " "
-                echo " "
-                echo "Proceso 1/2 concluido."
-                echo " "
-                echo -e "\e[1;34mSi ya has ejecutado esta opcion anteriormente y algo ha salido mal desmonta la consola y vuelve a ejecutar esta\e[0m"
-                echo -e "\e[1;34mopcion y, al llegar a este punto, desconecta la bateria y vuelve a conectarla antes de realizar lo siguiente.\e[0m"
-                echo " "
-                echo " "
-                echo -e "\e[1;31mPulsa y manten pulsado el boton de encendido y justo despues pulsa cualquier tecla para continuar...\e[0m"
-                read -n 1 -s -r -p ""
-                clear
-                cd /home/$usuario/gameandwatch/game-and-watch-patch
-                make clean
-                #make PATCH_PARAMS="--internal-only" flash_patched_int
-                make PATCH_PARAMS="--device=$consola --extended --no-la --no-sleep-images --extended" flash
-                cd -
-                echo " "
-                echo " "
-                echo "Proceso 2/2 concluido."
-                read -n 1 -s -r -p "Presiona cualquier tecla para continuar"
-            else
-                echo "No se ha encontrado internal_flash_backup_$consola.bin, cancelando..."
-                sleep 2
-            fi
-        else
-            echo "No se ha encontrado flash_backup_$consola.bin, cancelando..."
-            sleep 2
-        fi
-        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
-        --title "Instalar firmware original + Retro-Go  en consola con 4MB" \
-        --msgbox "Proceso realizado." 0 0
+        echo -e "\e[1;31mEnciende la consola y entra al menu Retro-Go con los botones LEFT+GAME y dejala esperando en el listado de las roms.\e[0m"
+        echo ""
+        echo -e "\e[1;31mPara continuar con el proceso pulsa cualquier tecla...\e[0m"
+        read -n 1 -s -r -p ""
+        cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
+        make -j$proc COMPRESS=lzma INTFLASH_BANK=2 EXTFLASH_SIZE=1802240 EXTFLASH_OFFSET=851968 GNW_TARGET=zelda EXTENDED=1 COVERFLOW=$caratula flash_saves_backup
+        cd -
+        #sleep 5
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.2-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso realizado. Save states descargados en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" 0 0
     else
-            dialog --backtitle "G&W $consola - Utilidades de flasheo" \
-            --title "Instalar firmware original + Retro-Go  en consola con 4MB" \
-            --msgbox "Proceso cancelado." 0 0
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.2-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso cancelado." 0 0
     fi
-    ./scene/2.2.2-cfw-retro-go-4mb-$consola.sh
+    ./scene/2.2.2-save-state-$consola.sh
     clear;;
   2)clear
-    dialog --backtitle "G&W $consola - Utilidades de flasheo" \
-    --title "Compilar Retro-Go" \
-    --yesno "Se procedera a compilar RetroGo y se incluiran las roms que existan en /home/$usuario/game-and-watch-retro-go/roms/. ¿Deseas continuar?" 0 0
+    dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.2-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+           --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+           --yesno "¡¡¡ATENCION!!! El proceso RESTAURACION de los save states puede llegar a tardar varios minutos dependiendo de la cantidad de roms que haya en la G&W y pararlo puede ocasionar errores. ¿Deseas continuar?" 0 0
     ans=$?
     if [ $ans -eq 0 ]; then
         clear
-        cd /home/$usuario/gameandwatch/game-and-watch-retro-go
-        make clean
-        make -j$proc COMPRESS=lzma INTFLASH_BANK=2 EXTFLASH_SIZE=1802240 EXTFLASH_OFFSET=851968 GNW_TARGET=zelda EXTENDED=1 COVERFLOW=$caratula
+        echo -e "\e[1;31mEnciende la consola y entra al menu Retro-Go con los botones LEFT+GAME y dejala esperando en el listado de las roms.\e[0m"
+        echo ""
+        echo -e "\e[1;31mPara continuar con el proceso pulsa cualquier tecla...\e[0m"
+        read -n 1 -s -r -p ""
+        cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
+        make -j$proc COMPRESS=lzma INTFLASH_BANK=2 EXTFLASH_SIZE=1802240 EXTFLASH_OFFSET=851968 GNW_TARGET=zelda EXTENDED=1 COVERFLOW=$caratula flash_saves_restore
         cd -
-        echo " "
-        echo " "
-        read -n 1 -s -r -p "Proceso concluido. Presiona cualquier tecla para continuar."
-        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
-        --title "Compilar Retro-Go" \
-        --msgbox "Proceso realizado." 0 0
+        #sleep 5
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.2-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso realizado." 0 0
     else
-        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
-        --title "Compilar Retro-Go" \
-        --msgbox "Proceso cancelado." 0 0
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.2-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso cancelado." 0 0
     fi
-    ./scene/2.2.2-cfw-retro-go-4mb-$consola.sh
+    ./scene/2.2.2-save-state-$consola.sh
     clear;;
   3)clear
-    dialog --backtitle "G&W $consola - Utilidades de flasheo" \
-    --title "Compilar Retro-Go" \
-    --yesno "Se recomienda realizar el proceso con la batería cargada al 100% para evitar problemas. Se flasheara solamente el emulador Retro-Go por lo que no tendremos el menu original. Las roms que existan en /home/$usuario/game-and-watch-retro-go/roms/ tambien se subiran a la consola." 0 0
+    dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.2-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+           --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+           --yesno "¡¡¡ATENCION!!! El proceso BORRAR los save states puede llegar a tardar varios minutos dependiendo de la cantidad de roms que haya en la G&W y pararlo puede ocasionar errores. ¿Deseas continuar?" 0 0
     ans=$?
     if [ $ans -eq 0 ]; then
         clear
-        echo " "
-        echo -e "\e[1;34mSi ya has ejecutado esta opcion anteriormente y algo ha salido mal desmonta la consola y vuelve a ejecutar esta\e[0m"
-        echo -e "\e[1;34mopcion y, al llegar a este punto, desconecta la bateria y vuelve a conectarla antes de realizar lo siguiente.\e[0m"
-        echo " "
-        echo " "
-        echo -e "\e[0;32mSi durante el siguiente proceso nos dice que ha fallado el flasheo, que no puede conectar y nos pregunta si\e[0m"
-        echo -e "\e[0;32mvamos a hacer un power cycle (quitar bateria, reconectar y encender) pulsaremos el boton de encendido y lo \e[0m"
-        echo -e "\e[0;32mmantendremos pulsado unos segundos, le diremos que si con \"y\" (yes), entonces el proceso continuara.\e[0m"
-        echo -e "\e[1;31mPulsa y manten pulsado el boton de encendido y justo despues pulsa cualquier tecla para continuar...\nATENCION: No sueltes el boton al menos hasta que empiece a borrar la memoria externa (cuando pone \"Erasing xxxx bytes...\" en la pantalla)\e[0m"
+        echo -e "\e[1;31mEnciende la consola y entra al menu Retro-Go con los botones LEFT+GAME y dejala esperando en el listado de las roms.\e[0m"
+        echo ""
+        echo -e "\e[1;31mPara continuar con el proceso pulsa cualquier tecla...\e[0m"
         read -n 1 -s -r -p ""
-        cd /home/$usuario/gameandwatch/game-and-watch-retro-go
-        #make clean
-        make -j$proc COMPRESS=lzma INTFLASH_BANK=2 EXTFLASH_SIZE=1802240 EXTFLASH_OFFSET=851968 GNW_TARGET=zelda EXTENDED=1 COVERFLOW=$caratula flash
+        cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
+        make -j$proc COMPRESS=lzma INTFLASH_BANK=2 EXTFLASH_SIZE=1802240 EXTFLASH_OFFSET=851968 GNW_TARGET=zelda EXTENDED=1 COVERFLOW=$caratula flash_saves_erase
         cd -
-        read -n 1 -s -r -p "Presiona cualquier tecla para continuar"
-        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
-        --title "Instalar solo Retro-Go" \
-        --msgbox "Proceso realizado." 0 0
+        #sleep 5
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.2-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso realizado." 0 0
     else
-        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
-        --title "Instalar solo Retro-Go" \
-        --msgbox "Proceso cancelado." 0 0
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.2-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso cancelado." 0 0
     fi
-    ./scene/2.2.2-cfw-retro-go-4mb-$consola.sh
+    ./scene/2.2.2-save-state-$consola.sh
     clear;;
 esac
 clear

--- a/scene/2.2.2-save-state-zelda.sh
+++ b/scene/2.2.2-save-state-zelda.sh
@@ -5,9 +5,9 @@ INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="zelda"
 proc="4"
-caratula="0"
+caratula="1"
 
-dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.2-cfw-retro-go-4mb-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.2-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
 --title "G&W CFW + Retro-Go 4MB /// INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Roms en /home/$usuario/game-and-watch-retro-go/roms/" \
 --ok-label Apply \
 --cancel-label Exit \

--- a/scene/2.2.3-cfw-retro-go-16mb-mario.sh
+++ b/scene/2.2.3-cfw-retro-go-16mb-mario.sh
@@ -5,7 +5,7 @@ INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="mario"
 proc="4"
-caratula="1"
+caratula="0"
 
 dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.3-cfw-retro-go-16mb-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
 --title "G&W menu de flasheo $consola 16MB" \

--- a/scene/2.2.3-cfw-retro-go-16mb-mario.sh
+++ b/scene/2.2.3-cfw-retro-go-16mb-mario.sh
@@ -4,7 +4,7 @@
 INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="mario"
-proc="6"
+proc="4"
 caratula="0"
 
 dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.3-cfw-retro-go-16mb-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \

--- a/scene/2.2.3-cfw-retro-go-16mb-mario.sh
+++ b/scene/2.2.3-cfw-retro-go-16mb-mario.sh
@@ -5,7 +5,7 @@ INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="mario"
 proc="4"
-caratula="0"
+caratula="1"
 
 dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.3-cfw-retro-go-16mb-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
 --title "G&W menu de flasheo $consola 16MB" \
@@ -252,6 +252,6 @@ case $menuitem in
     clear;;
   7)clear
     ./scene/2.2.3-save-state-$consola.sh
-	clear
+	clear;;
 esac
 clear

--- a/scene/2.2.3-cfw-retro-go-16mb-mario.sh
+++ b/scene/2.2.3-cfw-retro-go-16mb-mario.sh
@@ -21,6 +21,7 @@ Opcion caratulas: $caratula (0=NO y 1=SI)
 Roms: /home/$usuario/game-and-watch-retro-go/roms/
 
 Selecciona con las flechas la opcion deseada:" 0 0 0 \
+   H "Herramientas y utilidades" \
    1 "CFW \"slim\" con los parametros para 16MB" \
    2 "Compilar Retro-Go para CFW \"slim\" y parametros 16MB" \
    3 "Flashear Retro-Go para CFW \"slim\" y parametros 16MB" \
@@ -30,6 +31,10 @@ Selecciona con las flechas la opcion deseada:" 0 0 0 \
    7 "Descarga y restauracion de saves-states con parametros 16MB"   2>"${INPUT}"
 menuitem=$(<"${INPUT}")
 case $menuitem in
+  H)clear
+    ./scene/2.2.H-opcion-herramientas.sh
+    ./scene/2.2.3-cfw-retro-go-16mb-$consola.sh
+    clear;;
   1)clear
     dialog --backtitle "G&W $consola - Utilidades de flasheo" \
     --title "Instalar CFW slim en G&W $consola con 16MB" \

--- a/scene/2.2.3-cfw-retro-go-16mb-mario.sh
+++ b/scene/2.2.3-cfw-retro-go-16mb-mario.sh
@@ -76,7 +76,7 @@ case $menuitem in
             --title "Instalar firmware original + Retro-Go  en consola con 16MB" \
             --msgbox "Proceso cancelado." 0 0
     fi
-    ./scene/2.2.3-cfw-retro-go-16mb-$consola.sh/media/kde/WD-4tb/git/GnW/
+    ./scene/2.2.3-cfw-retro-go-16mb-$consola.sh
     clear;;
   2)clear
     dialog --backtitle "G&W $consola - Utilidades de flasheo" \
@@ -166,7 +166,7 @@ case $menuitem in
                 clear
                 cd /home/$usuario/gameandwatch/game-and-watch-patch
                 make clean
-                make PATCH_PARAMS="--device=$consola" flash_patched
+                make PATCH_PARAMS="--device=$consola" LARGE_FLASH=1 flash_patched
                 sleep 0.5
                 make reset
                 cd -
@@ -252,6 +252,7 @@ case $menuitem in
     clear;;
   7)clear
     ./scene/2.2.3-save-state-$consola.sh
+    ./scene/2.2.3-cfw-retro-go-16mb-$consola.sh
 	clear;;
 esac
 clear

--- a/scene/2.2.3-cfw-retro-go-16mb-mario.sh
+++ b/scene/2.2.3-cfw-retro-go-16mb-mario.sh
@@ -172,7 +172,7 @@ case $menuitem in
                 clear
                 cd /home/$usuario/gameandwatch/game-and-watch-patch
                 make clean
-                make PATCH_PARAMS="--device=$consola" LARGE_FLASH=1 flash_patched
+                make PATCH_PARAMS="--device=$consola" flash_patched
                 sleep 0.5
                 make reset
                 cd -

--- a/scene/2.2.3-cfw-retro-go-16mb-mario.sh
+++ b/scene/2.2.3-cfw-retro-go-16mb-mario.sh
@@ -4,7 +4,7 @@
 INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="mario"
-proc="4"
+proc="6"
 caratula="0"
 
 dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.3-cfw-retro-go-16mb-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
@@ -14,7 +14,13 @@ dialog --backtitle "G&W $consola - Utilidades de flasheo" \
 --title "G&W CFW + Retro-Go 16MB /// INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Roms en /home/$usuario/game-and-watch-retro-go/roms/" \
 --ok-label Apply \
 --cancel-label Exit \
---menu "Selecciona con las flechas la opcion deseada:" 15 140 15 \
+--menu "
+Usuario actual: $usuario
+Consola seleccionada: $consola
+Opcion caratulas: $caratula (0=NO y 1=SI)
+Roms: /home/$usuario/game-and-watch-retro-go/roms/
+
+Selecciona con las flechas la opcion deseada:" 0 0 0 \
    1 "CFW \"slim\" con los parametros para 16MB" \
    2 "Compilar Retro-Go para CFW \"slim\" y parametros 16MB" \
    3 "Flashear Retro-Go para CFW \"slim\" y parametros 16MB" \

--- a/scene/2.2.3-cfw-retro-go-16mb-mario.sh
+++ b/scene/2.2.3-cfw-retro-go-16mb-mario.sh
@@ -20,7 +20,8 @@ dialog --backtitle "G&W $consola - Utilidades de flasheo" \
    3 "Flashear Retro-Go para CFW \"slim\" y parametros 16MB" \
    4 "CFW \"full\" con los parametros para 16MB" \
    5 "Compilar Retro-Go para CFW \"full\" y parametros 16MB" \
-   6 "Flashear Retro-Go para CFW \"full\" y parametros 16MB" 2>"${INPUT}"
+   6 "Flashear Retro-Go para CFW \"full\" y parametros 16MB" \
+   7 "Descarga y restauracion de saves-states con parametros 16MB"   2>"${INPUT}"
 menuitem=$(<"${INPUT}")
 case $menuitem in
   1)clear
@@ -249,5 +250,8 @@ case $menuitem in
     fi
     ./scene/2.2.3-cfw-retro-go-16mb-$consola.sh
     clear;;
+  7)clear
+    ./scene/2.2.3-save-state-$consola.sh
+	clear
 esac
 clear

--- a/scene/2.2.3-cfw-retro-go-16mb-zelda.sh
+++ b/scene/2.2.3-cfw-retro-go-16mb-zelda.sh
@@ -4,7 +4,7 @@
 INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="zelda"
-proc="6"
+proc="4"
 caratula="0"
 
 #dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.3-cfw-retro-go-16mb-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
@@ -21,12 +21,17 @@ Opcion caratulas: $caratula (0=NO y 1=SI)
 Roms: /home/$usuario/game-and-watch-retro-go/roms/
 
 Selecciona con las flechas la opcion deseada:" 0 0 0 \
+   H "Herramientas y utilidades" \
    1 "CFW con los parametros para 16MB" \
    2 "Compilar Retro-Go para CFW y parametros 16MB" \
    3 "Flashear Retro-Go para CFW y parametros 16MB" \
    4 "Descarga y restauracion de saves-states con parametros 16MB"   2>"${INPUT}"
 menuitem=$(<"${INPUT}")
 case $menuitem in
+  H)clear
+    ./scene/2.2.H-opcion-herramientas.sh
+    ./scene/2.2.3-cfw-retro-go-16mb-$consola.sh
+    clear;;
   1)clear
     dialog --backtitle "G&W $consola - Utilidades de flasheo" \
     --title "Instalar CFW slim en G&W $consola con 16MB" \

--- a/scene/2.2.3-cfw-retro-go-16mb-zelda.sh
+++ b/scene/2.2.3-cfw-retro-go-16mb-zelda.sh
@@ -5,7 +5,7 @@ INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="zelda"
 proc="4"
-caratula="1"
+caratula="0"
 
 #dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.3-cfw-retro-go-16mb-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
 #--title "G&W menu de flasheo $consola 16MB" \

--- a/scene/2.2.3-cfw-retro-go-16mb-zelda.sh
+++ b/scene/2.2.3-cfw-retro-go-16mb-zelda.sh
@@ -5,7 +5,7 @@ INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="zelda"
 proc="4"
-caratula="0"
+caratula="1"
 
 #dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.3-cfw-retro-go-16mb-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
 #--title "G&W menu de flasheo $consola 16MB" \
@@ -137,6 +137,6 @@ case $menuitem in
     clear;;
   4)clear
     ./scene/2.2.3-save-state-$consola.sh
-	clear
+	clear;;
 esac
 clear

--- a/scene/2.2.3-cfw-retro-go-16mb-zelda.sh
+++ b/scene/2.2.3-cfw-retro-go-16mb-zelda.sh
@@ -137,6 +137,7 @@ case $menuitem in
     clear;;
   4)clear
     ./scene/2.2.3-save-state-$consola.sh
+    ./scene/2.2.3-cfw-retro-go-16mb-$consola.sh
 	clear;;
 esac
 clear

--- a/scene/2.2.3-cfw-retro-go-16mb-zelda.sh
+++ b/scene/2.2.3-cfw-retro-go-16mb-zelda.sh
@@ -4,7 +4,7 @@
 INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="zelda"
-proc="4"
+proc="6"
 caratula="0"
 
 #dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.3-cfw-retro-go-16mb-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
@@ -14,7 +14,13 @@ dialog --backtitle "G&W $consola - Utilidades de flasheo" \
 --title "G&W CFW + Retro-Go 16MB /// INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Roms en /home/$usuario/game-and-watch-retro-go/roms/" \
 --ok-label Apply \
 --cancel-label Exit \
---menu "Selecciona con las flechas la opcion deseada:" 15 140 15 \
+--menu "
+Usuario actual: $usuario
+Consola seleccionada: $consola
+Opcion caratulas: $caratula (0=NO y 1=SI)
+Roms: /home/$usuario/game-and-watch-retro-go/roms/
+
+Selecciona con las flechas la opcion deseada:" 0 0 0 \
    1 "CFW con los parametros para 16MB" \
    2 "Compilar Retro-Go para CFW y parametros 16MB" \
    3 "Flashear Retro-Go para CFW y parametros 16MB" \

--- a/scene/2.2.3-cfw-retro-go-16mb-zelda.sh
+++ b/scene/2.2.3-cfw-retro-go-16mb-zelda.sh
@@ -86,7 +86,7 @@ case $menuitem in
         clear
         cd /home/$usuario/gameandwatch/game-and-watch-retro-go
         make clean
-        make -j$proc EXTFLASH_SIZE_MB=12 EXTFLASH_OFFSET=4194304 INTFLASH_BANK=2 GNW_TARGET=$consola COVERFLOW=$caratula
+        make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=12 EXTFLASH_OFFSET=4194304 INTFLASH_BANK=2 GNW_TARGET=$consola COVERFLOW=$caratula
         cd -
         echo " "
         echo " "
@@ -120,7 +120,7 @@ case $menuitem in
         read -n 1 -s -r -p ""
         cd /home/$usuario/gameandwatch/game-and-watch-retro-go
         #make clean
-        make -j$proc EXTFLASH_SIZE_MB=12 EXTFLASH_OFFSET=4194304 INTFLASH_BANK=2 GNW_TARGET=$consola COVERFLOW=$caratula flash
+        make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=12 EXTFLASH_OFFSET=4194304 INTFLASH_BANK=2 GNW_TARGET=$consola COVERFLOW=$caratula flash
         cd -
         echo " "
         echo " "

--- a/scene/2.2.3-cfw-retro-go-16mb-zelda.sh
+++ b/scene/2.2.3-cfw-retro-go-16mb-zelda.sh
@@ -57,7 +57,7 @@ case $menuitem in
                 clear
                 cd /home/$usuario/gameandwatch/game-and-watch-patch
                 make clean
-                make PATCH_PARAMS="--device=$consola" LARGE_FLASH=1 flash_patched
+                make PATCH_PARAMS="--device=$consola" flash_patched
                 sleep 0.5
                 make reset
                 cd -

--- a/scene/2.2.3-cfw-retro-go-16mb-zelda.sh
+++ b/scene/2.2.3-cfw-retro-go-16mb-zelda.sh
@@ -17,7 +17,8 @@ dialog --backtitle "G&W $consola - Utilidades de flasheo" \
 --menu "Selecciona con las flechas la opcion deseada:" 15 140 15 \
    1 "CFW con los parametros para 16MB" \
    2 "Compilar Retro-Go para CFW y parametros 16MB" \
-   3 "Flashear Retro-Go para CFW y parametros 16MB" 2>"${INPUT}"
+   3 "Flashear Retro-Go para CFW y parametros 16MB" \
+   4 "Descarga y restauracion de saves-states con parametros 16MB"   2>"${INPUT}"
 menuitem=$(<"${INPUT}")
 case $menuitem in
   1)clear
@@ -134,5 +135,8 @@ case $menuitem in
     fi
     ./scene/2.2.3-cfw-retro-go-16mb-$consola.sh
     clear;;
+  4)clear
+    ./scene/2.2.3-save-state-$consola.sh
+	clear
 esac
 clear

--- a/scene/2.2.3-cfw-retro-go-16mb-zelda.sh
+++ b/scene/2.2.3-cfw-retro-go-16mb-zelda.sh
@@ -51,7 +51,7 @@ case $menuitem in
                 clear
                 cd /home/$usuario/gameandwatch/game-and-watch-patch
                 make clean
-                make PATCH_PARAMS="--device=$consola" flash_patched
+                make PATCH_PARAMS="--device=$consola" LARGE_FLASH=1 flash_patched
                 sleep 0.5
                 make reset
                 cd -

--- a/scene/2.2.3-save-state-mario.sh
+++ b/scene/2.2.3-save-state-mario.sh
@@ -5,7 +5,7 @@ INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="mario"
 proc="4"
-caratula="1"
+caratula="0"
 
 clear
 dpkg -s libncurses5 > libncurses5.txt
@@ -50,7 +50,8 @@ case $menuitem in
         cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
         make -j$proc COMPRESS=lzma INTFLASH_BANK=2 EXTFLASH_SIZE_MB=16 GNW_TARGET=$consola COVERFLOW=$caratula flash_saves_backup
         cd -
-        #sleep 5
+        echo -e "\e[1;31mPulsa cualquier tecla para continuar...\e[0m"
+        read -n 1 -s -r -p ""
         dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.3-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
                --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
                --msgbox "Proceso realizado. Save states descargados en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" 0 0
@@ -75,7 +76,8 @@ case $menuitem in
         cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
         make -j$proc COMPRESS=lzma INTFLASH_BANK=2 EXTFLASH_SIZE_MB=16 GNW_TARGET=$consola COVERFLOW=$caratula flash_saves_restore
         cd -
-        #sleep 5
+        echo -e "\e[1;31mPulsa cualquier tecla para continuar...\e[0m"
+        read -n 1 -s -r -p ""
         dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.3-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
                --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
                --msgbox "Proceso realizado." 0 0
@@ -100,7 +102,8 @@ case $menuitem in
         cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
         make -j$proc COMPRESS=lzma INTFLASH_BANK=2 EXTFLASH_SIZE_MB=16 GNW_TARGET=$consola COVERFLOW=$caratula flash_saves_erase
         cd -
-        #sleep 5
+        echo -e "\e[1;31mPulsa cualquier tecla para continuar...\e[0m"
+        read -n 1 -s -r -p ""
         dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.3-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
                --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
                --msgbox "Proceso realizado." 0 0
@@ -125,7 +128,8 @@ case $menuitem in
         cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
         make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=15 EXTFLASH_OFFSET=1048576 INTFLASH_BANK=2 GNW_TARGET=$consola COVERFLOW=$caratula flash_saves_backup
         cd -
-        #sleep 5
+        echo -e "\e[1;31mPulsa cualquier tecla para continuar...\e[0m"
+        read -n 1 -s -r -p ""
         dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.3-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
                --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
                --msgbox "Proceso realizado. Save states descargados en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" 0 0
@@ -150,7 +154,8 @@ case $menuitem in
         cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
         make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=15 EXTFLASH_OFFSET=1048576 INTFLASH_BANK=2 GNW_TARGET=$consola COVERFLOW=$caratula flash_saves_restore
         cd -
-        #sleep 5
+        echo -e "\e[1;31mPulsa cualquier tecla para continuar...\e[0m"
+        read -n 1 -s -r -p ""
         dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.3-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
                --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
                --msgbox "Proceso realizado." 0 0
@@ -175,7 +180,8 @@ case $menuitem in
         cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
         make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=15 EXTFLASH_OFFSET=1048576 INTFLASH_BANK=2 GNW_TARGET=$consola COVERFLOW=$caratula flash_saves_erase
         cd -
-        #sleep 5
+        echo -e "\e[1;31mPulsa cualquier tecla para continuar...\e[0m"
+        read -n 1 -s -r -p ""
         dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.3-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
                --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
                --msgbox "Proceso realizado." 0 0

--- a/scene/2.2.3-save-state-mario.sh
+++ b/scene/2.2.3-save-state-mario.sh
@@ -5,12 +5,9 @@ INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="mario"
 proc="4"
-caratula="0"
+caratula="1"
 
-dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.3-cfw-retro-go-16mb-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
---title "G&W menu de flasheo $consola 16MB" \
---msgbox "ATENCION:\n\n\nCFW \"slim\" significa que no habra cancion de mario, no habra imagenes a la hora de dormir, se comprimira el resto del firm y se usara un flash interno indocumentado que requiere el openocd modificado. Esto permite que todo el firmware funcione sin utilizar ningún flash externo.\n\nCFW \"full\" significa que se flasheara todo el firmware completo por lo que se usará parte de la flash externa con lo cual que se podran meter menos roms.\nPor contra se obtienen ciertos beneficios que son: tener la cancion de mario, las imagenes de dormir y se gestionarán mejor la configuracion y los highscores porque con CFW \"slim\" se pierden cuando la bateria esta baja o desenchufada" 0 0
-dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.3-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
 --title "G&W CFW + Retro-Go 16MB /// INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Roms en /home/$usuario/game-and-watch-retro-go/roms/" \
 --ok-label Apply \
 --cancel-label Exit \

--- a/scene/2.2.3-save-state-mario.sh
+++ b/scene/2.2.3-save-state-mario.sh
@@ -1,0 +1,253 @@
+#!/bin/bash
+#By julenvitoria
+
+INPUT=/tmp/$MENU.sh.$$
+usuario="kde"
+consola="mario"
+proc="4"
+caratula="0"
+
+dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.3-cfw-retro-go-16mb-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+--title "G&W menu de flasheo $consola 16MB" \
+--msgbox "ATENCION:\n\n\nCFW \"slim\" significa que no habra cancion de mario, no habra imagenes a la hora de dormir, se comprimira el resto del firm y se usara un flash interno indocumentado que requiere el openocd modificado. Esto permite que todo el firmware funcione sin utilizar ningún flash externo.\n\nCFW \"full\" significa que se flasheara todo el firmware completo por lo que se usará parte de la flash externa con lo cual que se podran meter menos roms.\nPor contra se obtienen ciertos beneficios que son: tener la cancion de mario, las imagenes de dormir y se gestionarán mejor la configuracion y los highscores porque con CFW \"slim\" se pierden cuando la bateria esta baja o desenchufada" 0 0
+dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+--title "G&W CFW + Retro-Go 16MB /// INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Roms en /home/$usuario/game-and-watch-retro-go/roms/" \
+--ok-label Apply \
+--cancel-label Exit \
+--menu "Selecciona con las flechas la opcion deseada:" 15 140 15 \
+   1 "CFW \"slim\" con los parametros para 16MB" \
+   2 "Compilar Retro-Go para CFW \"slim\" y parametros 16MB" \
+   3 "Flashear Retro-Go para CFW \"slim\" y parametros 16MB" \
+   4 "CFW \"full\" con los parametros para 16MB" \
+   5 "Compilar Retro-Go para CFW \"full\" y parametros 16MB" \
+   6 "Flashear Retro-Go para CFW \"full\" y parametros 16MB" 2>"${INPUT}"
+menuitem=$(<"${INPUT}")
+case $menuitem in
+  1)clear
+    dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+    --title "Instalar CFW slim en G&W $consola con 16MB" \
+    --yesno "Se recomienda realizar el proceso con la batería cargada al 100% para evitar problemas. Este proceso es solamente para una consola con el chip de 16MB.\n\n¡¡¡ATENCION!!!\nSI SE TIENE DIFERENTE CANTIDAD DE MEMORIA CANCELAR EL PROCESO y una vez vuelto al menu seleccionar el correcto.\n\nSe flasheara un custom firmware que consta del menu original de la consola ademas del emulador Retro-Go. El emulador aparecera al realizar el combo de botones \"LEFT\" + \"GAME\". Las roms que existan en /home/$usuario/game-and-watch-retro-go/roms/ tambien se subiran a la consola ¿Deseas continuar?" 0 0
+    ans=$?
+    if [ $ans -eq 0 ]; then
+        clear
+        if [ -f /home/$usuario/gameandwatch/game-and-watch-backup/backups/flash_backup_$consola.bin ]; then
+            echo "flash_backup_$consola.bin encontrado"
+            sleep 0.5
+            if [ -f /home/$usuario/gameandwatch/game-and-watch-backup/backups/internal_flash_backup_$consola.bin ]; then
+                echo "internal_flash_backup_$consola.bin encontrado"
+                sleep 0.5
+                cp /home/$usuario/gameandwatch/game-and-watch-backup/backups/flash_backup_$consola.bin /home/$usuario/gameandwatch/game-and-watch-patch
+                cp /home/$usuario/gameandwatch/game-and-watch-backup/backups/internal_flash_backup_$consola.bin /home/$usuario/gameandwatch/game-and-watch-patch
+                echo " "
+                echo "Se han copiado los archivos de la flash interna y externa"
+                echo " "
+                echo " "
+                echo "Proceso 1/2 concluido."
+                echo " "
+                echo -e "\e[1;34mSi ya has ejecutado esta opcion anteriormente y algo ha salido mal desmonta la consola y vuelve a ejecutar esta\e[0m"
+                echo -e "\e[1;34mopcion y, al llegar a este punto, desconecta la bateria y vuelve a conectarla antes de realizar lo siguiente.\e[0m"
+                echo " "
+                echo " "
+                echo -e "\e[1;31mPulsa y manten pulsado el boton de encendido y justo despues pulsa cualquier tecla para continuar...\e[0m"
+                read -n 1 -s -r -p ""
+                clear
+                cd /home/$usuario/gameandwatch/game-and-watch-patch
+                make clean
+                make PATCH_PARAMS="--device=$consola --internal-only" flash_patched
+                cd -
+                echo " "
+                echo " "
+                echo "Proceso 2/2 concluido."
+                read -n 1 -s -r -p "Presiona cualquier tecla para continuar"
+            else
+                echo "No se ha encontrado internal_flash_backup_$consola.bin, cancelando..."
+                sleep 2
+            fi
+        else
+            echo "No se ha encontrado flash_backup_$consola.bin, cancelando..."
+            sleep 2
+        fi
+        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+        --title "Instalar CFW en G&W $consola con 16MB" \
+        --msgbox "Proceso realizado." 0 0
+    else
+            dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+            --title "Instalar firmware original + Retro-Go  en consola con 16MB" \
+            --msgbox "Proceso cancelado." 0 0
+    fi
+    ./scene/2.2.3-cfw-retro-go-16mb-$consola.sh/media/kde/WD-4tb/git/GnW/
+    clear;;
+  2)clear
+    dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+    --title "Compilar Retro-Go" \
+    --yesno "Se procedera a compilar RetroGo con los parametros de memoria de 16mb pata CFW slim y se incluiran las roms que existan en /home/$usuario/game-and-watch-retro-go/roms/. ¿Deseas continuar?" 0 0
+    ans=$?
+    if [ $ans -eq 0 ]; then
+        clear
+        cd /home/$usuario/gameandwatch/game-and-watch-retro-go
+        make clean
+        make -j$proc COMPRESS=lzma INTFLASH_BANK=2 EXTFLASH_SIZE_MB=16 GNW_TARGET=$consola COVERFLOW=$caratula
+        cd -
+        echo " "
+        echo " "
+        read -n 1 -s -r -p "Proceso concluido. Presiona cualquier tecla para continuar."
+        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+        --title "Compilar Retro-Go" \
+        --msgbox "Proceso realizado." 0 0
+    else
+        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+        --title "Compilar Retro-Go" \
+        --msgbox "Proceso cancelado." 0 0
+    fi
+    ./scene/2.2.3-cfw-retro-go-16mb-$consola.sh
+    clear;;
+  3)clear
+    dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+    --title "Instalar Retro-Go" \
+    --yesno "Se recomienda realizar el proceso con la batería cargada al 100% para evitar problemas. Se flasheara solamente el emulador Retro-Go por lo que no tendremos el menu original. Las roms que existan en /home/$usuario/game-and-watch-retro-go/roms/ tambien se subiran a la consola." 0 0
+    ans=$?
+    if [ $ans -eq 0 ]; then
+        clear
+        echo " "
+        echo -e "\e[1;34mSi ya has ejecutado esta opcion anteriormente y algo ha salido mal desmonta la consola y vuelve a ejecutar esta\e[0m"
+        echo -e "\e[1;34mopcion y, al llegar a este punto, desconecta la bateria y vuelve a conectarla antes de realizar lo siguiente.\e[0m"
+        echo " "
+        echo " "
+        echo -e "\e[0;32mSi durante el siguiente proceso nos dice que ha fallado el flasheo, que no puede conectar y nos pregunta si\e[0m"
+        echo -e "\e[0;32mvamos a hacer un power cycle (quitar bateria, reconectar y encender) pulsaremos el boton de encendido y lo \e[0m"
+        echo -e "\e[0;32mmantendremos pulsado unos segundos, le diremos que si con \"y\" (yes), entonces el proceso continuara.\e[0m"
+        echo -e "\e[1;31mPulsa y manten pulsado el boton de encendido y justo despues pulsa cualquier tecla para continuar...\nATENCION: No sueltes el boton al menos hasta que empiece a borrar la memoria externa (cuando pone \"Erasing xxxx bytes...\" en la pantalla)\e[0m"
+        read -n 1 -s -r -p ""
+        cd /home/$usuario/gameandwatch/game-and-watch-retro-go
+        #make clean
+        make -j$proc COMPRESS=lzma INTFLASH_BANK=2 EXTFLASH_SIZE_MB=16 GNW_TARGET=$consola COVERFLOW=$caratula flash
+        cd -
+        echo " "
+        echo " "
+        read -n 1 -s -r -p "Proceso concluido. Presiona cualquier tecla para continuar."
+        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+        --title "Instalar solo Retro-Go" \
+        --msgbox "Proceso realizado." 0 0
+    else
+        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+        --title "Instalar solo Retro-Go" \
+        --msgbox "Proceso cancelado." 0 0
+    fi
+    ./scene/2.2.3-cfw-retro-go-16mb-$consola.sh
+    clear;;
+  4)clear
+    dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+    --title "Instalar CFW en G&W $consola con 16/media/kde/WD-4tb/git/GnW/MB" \
+    --yesno "Se recomienda realizar el proceso con la batería cargada al 100% para evitar problemas. Este proceso es solamente para una consola con el chip de 16MB.\n\n¡¡¡ATENCION!!!\nSI SE TIENE DIFERENTE CANTIDAD DE MEMORIA CANCELAR EL PROCESO y una vez vuelto al menu seleccionar el correcto.\n\nSe flasheara un custom firmware que consta del menu original de la consola ademas del acceso al emulador Retro-Go. El emulador aparecera al realizar el combo de botones \"LEFT\" + \"GAME\". ¿Deseas continuar?" 0 0
+    ans=$?
+    if [ $ans -eq 0 ]; then
+        clear
+        if [ -f /home/$usuario/gameandwatch/game-and-watch-backup/backups/flash_backup_$consola.bin ]; then
+            echo "flash_backup_$consola.bin encontrado"
+            sleep 0.5
+            if [ -f /home/$usuario/gameandwatch/game-and-watch-backup/backups/internal_flash_backup_$consola.bin ]; then
+                echo "internal_flash_backup_$consola.bin encontrado"
+                sleep 0.5
+                cp /home/$usuario/gameandwatch/game-and-watch-backup/backups/flash_backup_$consola.bin /home/$usuario/gameandwatch/game-and-watch-patch
+                cp /home/$usuario/gameandwatch/game-and-watch-backup/backups/internal_flash_backup_$consola.bin /home/$usuario/gameandwatch/game-and-watch-patch
+                echo " "
+                echo "Se han copiado los archivos de la flash interna y externa"
+                echo " "
+                echo " "
+                echo "Proceso 1/2 concluido."
+                echo " "
+                echo -e "\e[1;34mSi ya has ejecutado esta opcion anteriormente y algo ha salido mal desmonta la consola y vuelve a ejecutar esta\e[0m"
+                echo -e "\e[1;34mopcion y, al llegar a este punto, desconecta la bateria y vuelve a conectarla antes de realizar lo siguiente.\e[0m"
+                echo " "
+                echo " "
+                echo -e "\e[1;31mPulsa y manten pulsado el boton de encendido y justo despues pulsa cualquier tecla para continuar...\e[0m"
+                read -n 1 -s -r -p ""
+                clear
+                cd /home/$usuario/gameandwatch/game-and-watch-patch
+                make clean
+                make PATCH_PARAMS="--device=$consola" flash_patched
+                sleep 0.5
+                make reset
+                cd -
+                echo " "
+                echo " "
+                echo "Proceso 2/2 concluido."
+                read -n 1 -s -r -p "Presiona cualquier tecla para continuar"
+            else
+                echo "No se ha encontrado internal_flash_backup_$consola.bin, cancelando..."
+                sleep 2
+            fi
+        else
+            echo "No se ha encontrado flash_backup_$consola.bin, cancelando..."
+            sleep 2
+        fi
+        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+        --title "Instalar CFW en G&W $consola con 16MB" \
+        --msgbox "Proceso realizado." 0 0
+    else
+            dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+            --title "Instalar firmware original + Retro-Go  en consola con 16MB" \
+            --msgbox "Proceso cancelado." 0 0
+    fi
+    ./scene/2.2.3-cfw-retro-go-16mb-$consola.sh
+    clear;;
+  5)clear
+    dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+    --title "Compilar Retro-Go" \
+    --yesno "Se procedera a compilar RetroGo con los parametros de memoria de 16mb para CFW NO slim y se incluiran las roms que existan en /home/$usuario/game-and-watch-retro-go/roms/. ¿Deseas continuar?" 0 0
+    ans=$?
+    if [ $ans -eq 0 ]; then
+        clear
+        cd /home/$usuario/gameandwatch/game-and-watch-retro-go
+        make clean
+        make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=15 EXTFLASH_OFFSET=1048576 INTFLASH_BANK=2 GNW_TARGET=$consola COVERFLOW=$caratula
+		cd -
+        echo " "
+        echo " "
+        read -n 1 -s -r -p "Proceso concluido. Presiona cualquier tecla para continuar."
+        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+        --title "Compilar Retro-Go" \
+        --msgbox "Proceso realizado." 0 0
+    else
+        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+        --title "Compilar Retro-Go" \
+        --msgbox "Proceso cancelado." 0 0
+    fi
+    ./scene/2.2.3-cfw-retro-go-16mb-$consola.sh
+    clear;;
+  6)clear
+    dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+    --title "Instalar solo Retro-Go" \
+    --yesno "Se recomienda realizar el proceso con la batería cargada al 100% para evitar problemas. Se flasheara solamente el emulador Retro-Go por lo que no tendremos el menu original. Las roms que existan en /home/$usuario/game-and-watch-retro-go/roms/ tambien se subiran a la consola." 0 0
+    ans=$?
+    if [ $ans -eq 0 ]; then
+        clear
+        echo " "
+        echo -e "\e[1;34mSi ya has ejecutado esta opcion anteriormente y algo ha salido mal desmonta la consola y vuelve a ejecutar esta\e[0m"
+        echo -e "\e[1;34mopcion y, al llegar a este punto, desconecta la bateria y vuelve a conectarla antes de realizar lo siguiente.\e[0m"
+        echo " "
+        echo " "
+        echo -e "\e[0;32mSi durante el siguiente proceso nos dice que ha fallado el flasheo, que no puede conectar y nos pregunta si\e[0m"
+        echo -e "\e[0;32mvamos a hacer un power cycle (quitar bateria, reconectar y encender) pulsaremos el boton de encendido y lo \e[0m"
+        echo -e "\e[0;32mmantendremos pulsado unos segundos, le diremos que si con \"y\" (yes), entonces el proceso continuara.\e[0m"
+        echo -e "\e[1;31mPulsa y manten pulsado el boton de encendido y justo despues pulsa cualquier tecla para continuar...\nATENCION: No sueltes el boton al menos hasta que empiece a borrar la memoria externa (cuando pone \"Erasing xxxx bytes...\" en la pantalla)\e[0m"
+        read -n 1 -s -r -p ""
+        cd /home/$usuario/gameandwatch/game-and-watch-retro-go
+        #make clean
+        make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=15 EXTFLASH_OFFSET=1048576 INTFLASH_BANK=2 GNW_TARGET=$consola COVERFLOW=$caratula flash
+        cd -
+        echo " "
+        echo " "
+        read -n 1 -s -r -p "Proceso concluido. Presiona cualquier tecla para continuar."
+        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+        --title "Instalar solo Retro-Go" \
+        --msgbox "Proceso realizado." 0 0
+    else
+        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+        --title "Instalar solo Retro-Go" \
+        --msgbox "Proceso cancelado." 0 0
+    fi
+    ./scene/2.2.3-cfw-retro-go-16mb-$consola.sh
+    clear;;
+esac
+clear

--- a/scene/2.2.3-save-state-mario.sh
+++ b/scene/2.2.3-save-state-mario.sh
@@ -27,7 +27,7 @@ dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO
        --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
        --ok-label Apply \
        --cancel-label Exit \
-       --menu "Selecciona con las flechas la opcion deseada:" 12 140 15 \
+       --menu "Selecciona con las flechas la opcion deseada:" 14 140 15 \
           1 "Hacer backup de los save states existentes que hay en la G&W con chip de 16MB y CFW slim" \
           2 "Restaurar los save states desde el pc a la G&W con chip de 16MB y CFW slim" \
           3 "Borrar los saves states existentes en la G&W con chip de 16MB y CFW slim para dejarla limpia" \

--- a/scene/2.2.3-save-state-mario.sh
+++ b/scene/2.2.3-save-state-mario.sh
@@ -4,7 +4,7 @@
 INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="mario"
-proc="6"
+proc="4"
 caratula="0"
 
 clear

--- a/scene/2.2.3-save-state-mario.sh
+++ b/scene/2.2.3-save-state-mario.sh
@@ -7,248 +7,184 @@ consola="mario"
 proc="4"
 caratula="1"
 
+clear
+dpkg -s libncurses5 > libncurses5.txt
+if grep "install ok installed" ./libncurses5.txt ; then
+        echo "Encontrado paquete libncurses5, se prosigue..."
+        sleep 0.5
+else
+        echo "No encontrado paquete dialog necesario, instalando..."
+        echo " "
+        sudo apt install -y libncurses5
+        echo " "
+        echo "Instalado!!"
+        sleep 0.5
+fi
+
 dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.3-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
---title "G&W CFW + Retro-Go 16MB /// INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Roms en /home/$usuario/game-and-watch-retro-go/roms/" \
---ok-label Apply \
---cancel-label Exit \
---menu "Selecciona con las flechas la opcion deseada:" 15 140 15 \
-   1 "prueba" \
-   2 "Compilar Retro-Go para CFW \"slim\" y parametros 16MB" \
-   3 "Flashear Retro-Go para CFW \"slim\" y parametros 16MB" \
-   4 "CFW \"full\" con los parametros para 16MB" \
-   5 "Compilar Retro-Go para CFW \"full\" y parametros 16MB" \
-   6 "Flashear Retro-Go para CFW \"full\" y parametros 16MB" \
-   7 "Descarga y restauracion de saves-states con parametros 16MB"   2>"${INPUT}"
+       --msgbox "G&W Utilidad para backup, resturacion y borrado de save states. Una vez descargados los save states estan ubicados en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" 0 0
+dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.3-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+       --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+       --ok-label Apply \
+       --cancel-label Exit \
+       --menu "Selecciona con las flechas la opcion deseada:" 12 140 15 \
+          1 "Hacer backup de los save states existentes que hay en la G&W con chip de 16MB y CFW slim" \
+          2 "Restaurar los save states desde el pc a la G&W con chip de 16MB y CFW slim" \
+          3 "Borrar los saves states existentes en la G&W con chip de 16MB y CFW slim para dejarla limpia" \
+          4 "Hacer backup de los save states existentes que hay en la G&W con chip de 16MB y CFW full" \
+          5 "Restaurar los save states desde el pc a la G&W con chip de 16MB y CFW full" \
+          6 "Borrar los saves states existentes en la G&W con chip de 16MB y CFW full para dejarla limpia"   2>"${INPUT}"
 menuitem=$(<"${INPUT}")
 case $menuitem in
   1)clear
-    dialog --backtitle "G&W $consola - Utilidades de flasheo" \
-    --title "Instalar CFW slim en G&W $consola con 16MB" \
-    --yesno "Se recomienda realizar el proceso con la batería cargada al 100% para evitar problemas. Este proceso es solamente para una consola con el chip de 16MB.\n\n¡¡¡ATENCION!!!\nSI SE TIENE DIFERENTE CANTIDAD DE MEMORIA CANCELAR EL PROCESO y una vez vuelto al menu seleccionar el correcto.\n\nSe flasheara un custom firmware que consta del menu original de la consola ademas del emulador Retro-Go. El emulador aparecera al realizar el combo de botones \"LEFT\" + \"GAME\". Las roms que existan en /home/$usuario/game-and-watch-retro-go/roms/ tambien se subiran a la consola ¿Deseas continuar?" 0 0
+    dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.3-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+           --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+           --yesno "¡¡¡ATENCION!!! El proceso de BACKUP de los save states puede llegar a tardar varios minutos dependiendo de la cantidad de roms que haya en la G&W y pararlo puede ocasionar errores. ¿Deseas continuar?" 0 0
     ans=$?
     if [ $ans -eq 0 ]; then
         clear
-        if [ -f /home/$usuario/gameandwatch/game-and-watch-backup/backups/flash_backup_$consola.bin ]; then
-            echo "flash_backup_$consola.bin encontrado"
-            sleep 0.5
-            if [ -f /home/$usuario/gameandwatch/game-and-watch-backup/backups/internal_flash_backup_$consola.bin ]; then
-                echo "internal_flash_backup_$consola.bin encontrado"
-                sleep 0.5
-                cp /home/$usuario/gameandwatch/game-and-watch-backup/backups/flash_backup_$consola.bin /home/$usuario/gameandwatch/game-and-watch-patch
-                cp /home/$usuario/gameandwatch/game-and-watch-backup/backups/internal_flash_backup_$consola.bin /home/$usuario/gameandwatch/game-and-watch-patch
-                echo " "
-                echo "Se han copiado los archivos de la flash interna y externa"
-                echo " "
-                echo " "
-                echo "Proceso 1/2 concluido."
-                echo " "
-                echo -e "\e[1;34mSi ya has ejecutado esta opcion anteriormente y algo ha salido mal desmonta la consola y vuelve a ejecutar esta\e[0m"
-                echo -e "\e[1;34mopcion y, al llegar a este punto, desconecta la bateria y vuelve a conectarla antes de realizar lo siguiente.\e[0m"
-                echo " "
-                echo " "
-                echo -e "\e[1;31mPulsa y manten pulsado el boton de encendido y justo despues pulsa cualquier tecla para continuar...\e[0m"
-                read -n 1 -s -r -p ""
-                clear
-                cd /home/$usuario/gameandwatch/game-and-watch-patch
-                make clean
-                make PATCH_PARAMS="--device=$consola --internal-only" flash_patched
-                cd -
-                echo " "
-                echo " "
-                echo "Proceso 2/2 concluido."
-                read -n 1 -s -r -p "Presiona cualquier tecla para continuar"
-            else
-                echo "No se ha encontrado internal_flash_backup_$consola.bin, cancelando..."
-                sleep 2
-            fi
-        else
-            echo "No se ha encontrado flash_backup_$consola.bin, cancelando..."
-            sleep 2
-        fi
-        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
-        --title "Instalar CFW en G&W $consola con 16MB" \
-        --msgbox "Proceso realizado." 0 0
+        echo -e "\e[1;31mEnciende la consola y entra al menu Retro-Go con los botones LEFT+GAME y dejala esperando en el listado de las roms.\e[0m"
+        echo ""
+        echo -e "\e[1;31mPara continuar con el proceso pulsa cualquier tecla...\e[0m"
+        read -n 1 -s -r -p ""
+        cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
+        make -j$proc COMPRESS=lzma INTFLASH_BANK=2 EXTFLASH_SIZE_MB=16 GNW_TARGET=$consola COVERFLOW=$caratula flash_saves_backup
+        cd -
+        #sleep 5
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.3-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso realizado. Save states descargados en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" 0 0
     else
-            dialog --backtitle "G&W $consola - Utilidades de flasheo" \
-            --title "Instalar firmware original + Retro-Go  en consola con 16MB" \
-            --msgbox "Proceso cancelado." 0 0
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.3-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso cancelado." 0 0
     fi
-    ./scene/2.2.3-cfw-retro-go-16mb-$consola.sh/media/kde/WD-4tb/git/GnW/
+    ./scene/2.2.3-save-state-$consola.sh
     clear;;
   2)clear
-    dialog --backtitle "G&W $consola - Utilidades de flasheo" \
-    --title "Compilar Retro-Go" \
-    --yesno "Se procedera a compilar RetroGo con los parametros de memoria de 16mb pata CFW slim y se incluiran las roms que existan en /home/$usuario/game-and-watch-retro-go/roms/. ¿Deseas continuar?" 0 0
+    dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.3-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+           --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+           --yesno "¡¡¡ATENCION!!! El proceso RESTAURACION de los save states puede llegar a tardar varios minutos dependiendo de la cantidad de roms que haya en la G&W y pararlo puede ocasionar errores. ¿Deseas continuar?" 0 0
     ans=$?
     if [ $ans -eq 0 ]; then
         clear
-        cd /home/$usuario/gameandwatch/game-and-watch-retro-go
-        make clean
-        make -j$proc COMPRESS=lzma INTFLASH_BANK=2 EXTFLASH_SIZE_MB=16 GNW_TARGET=$consola COVERFLOW=$caratula
+        echo -e "\e[1;31mEnciende la consola y entra al menu Retro-Go con los botones LEFT+GAME y dejala esperando en el listado de las roms.\e[0m"
+        echo ""
+        echo -e "\e[1;31mPara continuar con el proceso pulsa cualquier tecla...\e[0m"
+        read -n 1 -s -r -p ""
+        cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
+        make -j$proc COMPRESS=lzma INTFLASH_BANK=2 EXTFLASH_SIZE_MB=16 GNW_TARGET=$consola COVERFLOW=$caratula flash_saves_restore
         cd -
-        echo " "
-        echo " "
-        read -n 1 -s -r -p "Proceso concluido. Presiona cualquier tecla para continuar."
-        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
-        --title "Compilar Retro-Go" \
-        --msgbox "Proceso realizado." 0 0
+        #sleep 5
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.3-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso realizado." 0 0
     else
-        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
-        --title "Compilar Retro-Go" \
-        --msgbox "Proceso cancelado." 0 0
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.3-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso cancelado." 0 0
     fi
-    ./scene/2.2.3-cfw-retro-go-16mb-$consola.sh
+    ./scene/2.2.3-save-state-$consola.sh
     clear;;
   3)clear
-    dialog --backtitle "G&W $consola - Utilidades de flasheo" \
-    --title "Instalar Retro-Go" \
-    --yesno "Se recomienda realizar el proceso con la batería cargada al 100% para evitar problemas. Se flasheara solamente el emulador Retro-Go por lo que no tendremos el menu original. Las roms que existan en /home/$usuario/game-and-watch-retro-go/roms/ tambien se subiran a la consola." 0 0
+    dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.3-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+           --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+           --yesno "¡¡¡ATENCION!!! El proceso BORRAR los save states puede llegar a tardar varios minutos dependiendo de la cantidad de roms que haya en la G&W y pararlo puede ocasionar errores. ¿Deseas continuar?" 0 0
     ans=$?
     if [ $ans -eq 0 ]; then
         clear
-        echo " "
-        echo -e "\e[1;34mSi ya has ejecutado esta opcion anteriormente y algo ha salido mal desmonta la consola y vuelve a ejecutar esta\e[0m"
-        echo -e "\e[1;34mopcion y, al llegar a este punto, desconecta la bateria y vuelve a conectarla antes de realizar lo siguiente.\e[0m"
-        echo " "
-        echo " "
-        echo -e "\e[0;32mSi durante el siguiente proceso nos dice que ha fallado el flasheo, que no puede conectar y nos pregunta si\e[0m"
-        echo -e "\e[0;32mvamos a hacer un power cycle (quitar bateria, reconectar y encender) pulsaremos el boton de encendido y lo \e[0m"
-        echo -e "\e[0;32mmantendremos pulsado unos segundos, le diremos que si con \"y\" (yes), entonces el proceso continuara.\e[0m"
-        echo -e "\e[1;31mPulsa y manten pulsado el boton de encendido y justo despues pulsa cualquier tecla para continuar...\nATENCION: No sueltes el boton al menos hasta que empiece a borrar la memoria externa (cuando pone \"Erasing xxxx bytes...\" en la pantalla)\e[0m"
+        echo -e "\e[1;31mEnciende la consola y entra al menu Retro-Go con los botones LEFT+GAME y dejala esperando en el listado de las roms.\e[0m"
+        echo ""
+        echo -e "\e[1;31mPara continuar con el proceso pulsa cualquier tecla...\e[0m"
         read -n 1 -s -r -p ""
-        cd /home/$usuario/gameandwatch/game-and-watch-retro-go
-        #make clean
-        make -j$proc COMPRESS=lzma INTFLASH_BANK=2 EXTFLASH_SIZE_MB=16 GNW_TARGET=$consola COVERFLOW=$caratula flash
+        cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
+        make -j$proc COMPRESS=lzma INTFLASH_BANK=2 EXTFLASH_SIZE_MB=16 GNW_TARGET=$consola COVERFLOW=$caratula flash_saves_erase
         cd -
-        echo " "
-        echo " "
-        read -n 1 -s -r -p "Proceso concluido. Presiona cualquier tecla para continuar."
-        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
-        --title "Instalar solo Retro-Go" \
-        --msgbox "Proceso realizado." 0 0
+        #sleep 5
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.3-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso realizado." 0 0
     else
-        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
-        --title "Instalar solo Retro-Go" \
-        --msgbox "Proceso cancelado." 0 0
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.3-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso cancelado." 0 0
     fi
-    ./scene/2.2.3-cfw-retro-go-16mb-$consola.sh
+    ./scene/2.2.3-save-state-$consola.sh
     clear;;
   4)clear
-    dialog --backtitle "G&W $consola - Utilidades de flasheo" \
-    --title "Instalar CFW en G&W $consola con 16/media/kde/WD-4tb/git/GnW/MB" \
-    --yesno "Se recomienda realizar el proceso con la batería cargada al 100% para evitar problemas. Este proceso es solamente para una consola con el chip de 16MB.\n\n¡¡¡ATENCION!!!\nSI SE TIENE DIFERENTE CANTIDAD DE MEMORIA CANCELAR EL PROCESO y una vez vuelto al menu seleccionar el correcto.\n\nSe flasheara un custom firmware que consta del menu original de la consola ademas del acceso al emulador Retro-Go. El emulador aparecera al realizar el combo de botones \"LEFT\" + \"GAME\". ¿Deseas continuar?" 0 0
+    dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.3-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+           --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+           --yesno "¡¡¡ATENCION!!! El proceso de BACKUP de los save states puede llegar a tardar varios minutos dependiendo de la cantidad de roms que haya en la G&W y pararlo puede ocasionar errores. ¿Deseas continuar?" 0 0
     ans=$?
     if [ $ans -eq 0 ]; then
         clear
-        if [ -f /home/$usuario/gameandwatch/game-and-watch-backup/backups/flash_backup_$consola.bin ]; then
-            echo "flash_backup_$consola.bin encontrado"
-            sleep 0.5
-            if [ -f /home/$usuario/gameandwatch/game-and-watch-backup/backups/internal_flash_backup_$consola.bin ]; then
-                echo "internal_flash_backup_$consola.bin encontrado"
-                sleep 0.5
-                cp /home/$usuario/gameandwatch/game-and-watch-backup/backups/flash_backup_$consola.bin /home/$usuario/gameandwatch/game-and-watch-patch
-                cp /home/$usuario/gameandwatch/game-and-watch-backup/backups/internal_flash_backup_$consola.bin /home/$usuario/gameandwatch/game-and-watch-patch
-                echo " "
-                echo "Se han copiado los archivos de la flash interna y externa"
-                echo " "
-                echo " "
-                echo "Proceso 1/2 concluido."
-                echo " "
-                echo -e "\e[1;34mSi ya has ejecutado esta opcion anteriormente y algo ha salido mal desmonta la consola y vuelve a ejecutar esta\e[0m"
-                echo -e "\e[1;34mopcion y, al llegar a este punto, desconecta la bateria y vuelve a conectarla antes de realizar lo siguiente.\e[0m"
-                echo " "
-                echo " "
-                echo -e "\e[1;31mPulsa y manten pulsado el boton de encendido y justo despues pulsa cualquier tecla para continuar...\e[0m"
-                read -n 1 -s -r -p ""
-                clear
-                cd /home/$usuario/gameandwatch/game-and-watch-patch
-                make clean
-                make PATCH_PARAMS="--device=$consola" flash_patched
-                sleep 0.5
-                make reset
-                cd -
-                echo " "
-                echo " "
-                echo "Proceso 2/2 concluido."
-                read -n 1 -s -r -p "Presiona cualquier tecla para continuar"
-            else
-                echo "No se ha encontrado internal_flash_backup_$consola.bin, cancelando..."
-                sleep 2
-            fi
-        else
-            echo "No se ha encontrado flash_backup_$consola.bin, cancelando..."
-            sleep 2
-        fi
-        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
-        --title "Instalar CFW en G&W $consola con 16MB" \
-        --msgbox "Proceso realizado." 0 0
+        echo -e "\e[1;31mEnciende la consola y entra al menu Retro-Go con los botones LEFT+GAME y dejala esperando en el listado de las roms.\e[0m"
+        echo ""
+        echo -e "\e[1;31mPara continuar con el proceso pulsa cualquier tecla...\e[0m"
+        read -n 1 -s -r -p ""
+        cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
+        make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=15 EXTFLASH_OFFSET=1048576 INTFLASH_BANK=2 GNW_TARGET=$consola COVERFLOW=$caratula flash_saves_backup
+        cd -
+        #sleep 5
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.3-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso realizado. Save states descargados en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" 0 0
     else
-            dialog --backtitle "G&W $consola - Utilidades de flasheo" \
-            --title "Instalar firmware original + Retro-Go  en consola con 16MB" \
-            --msgbox "Proceso cancelado." 0 0
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.3-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso cancelado." 0 0
     fi
-    ./scene/2.2.3-cfw-retro-go-16mb-$consola.sh
+    ./scene/2.2.3-save-state-$consola.sh
     clear;;
   5)clear
-    dialog --backtitle "G&W $consola - Utilidades de flasheo" \
-    --title "Compilar Retro-Go" \
-    --yesno "Se procedera a compilar RetroGo con los parametros de memoria de 16mb para CFW NO slim y se incluiran las roms que existan en /home/$usuario/game-and-watch-retro-go/roms/. ¿Deseas continuar?" 0 0
+    dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.3-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+           --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+           --yesno "¡¡¡ATENCION!!! El proceso RESTAURACION de los save states puede llegar a tardar varios minutos dependiendo de la cantidad de roms que haya en la G&W y pararlo puede ocasionar errores. ¿Deseas continuar?" 0 0
     ans=$?
     if [ $ans -eq 0 ]; then
         clear
-        cd /home/$usuario/gameandwatch/game-and-watch-retro-go
-        make clean
-        make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=15 EXTFLASH_OFFSET=1048576 INTFLASH_BANK=2 GNW_TARGET=$consola COVERFLOW=$caratula
-		cd -
-        echo " "
-        echo " "
-        read -n 1 -s -r -p "Proceso concluido. Presiona cualquier tecla para continuar."
-        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
-        --title "Compilar Retro-Go" \
-        --msgbox "Proceso realizado." 0 0
+        echo -e "\e[1;31mEnciende la consola y entra al menu Retro-Go con los botones LEFT+GAME y dejala esperando en el listado de las roms.\e[0m"
+        echo ""
+        echo -e "\e[1;31mPara continuar con el proceso pulsa cualquier tecla...\e[0m"
+        read -n 1 -s -r -p ""
+        cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
+        make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=15 EXTFLASH_OFFSET=1048576 INTFLASH_BANK=2 GNW_TARGET=$consola COVERFLOW=$caratula flash_saves_restore
+        cd -
+        #sleep 5
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.3-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso realizado." 0 0
     else
-        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
-        --title "Compilar Retro-Go" \
-        --msgbox "Proceso cancelado." 0 0
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.3-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso cancelado." 0 0
     fi
-    ./scene/2.2.3-cfw-retro-go-16mb-$consola.sh
+    ./scene/2.2.3-save-state-$consola.sh
     clear;;
   6)clear
-    dialog --backtitle "G&W $consola - Utilidades de flasheo" \
-    --title "Instalar solo Retro-Go" \
-    --yesno "Se recomienda realizar el proceso con la batería cargada al 100% para evitar problemas. Se flasheara solamente el emulador Retro-Go por lo que no tendremos el menu original. Las roms que existan en /home/$usuario/game-and-watch-retro-go/roms/ tambien se subiran a la consola." 0 0
+    dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.3-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+           --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+           --yesno "¡¡¡ATENCION!!! El proceso BORRAR los save states puede llegar a tardar varios minutos dependiendo de la cantidad de roms que haya en la G&W y pararlo puede ocasionar errores. ¿Deseas continuar?" 0 0
     ans=$?
     if [ $ans -eq 0 ]; then
         clear
-        echo " "
-        echo -e "\e[1;34mSi ya has ejecutado esta opcion anteriormente y algo ha salido mal desmonta la consola y vuelve a ejecutar esta\e[0m"
-        echo -e "\e[1;34mopcion y, al llegar a este punto, desconecta la bateria y vuelve a conectarla antes de realizar lo siguiente.\e[0m"
-        echo " "
-        echo " "
-        echo -e "\e[0;32mSi durante el siguiente proceso nos dice que ha fallado el flasheo, que no puede conectar y nos pregunta si\e[0m"
-        echo -e "\e[0;32mvamos a hacer un power cycle (quitar bateria, reconectar y encender) pulsaremos el boton de encendido y lo \e[0m"
-        echo -e "\e[0;32mmantendremos pulsado unos segundos, le diremos que si con \"y\" (yes), entonces el proceso continuara.\e[0m"
-        echo -e "\e[1;31mPulsa y manten pulsado el boton de encendido y justo despues pulsa cualquier tecla para continuar...\nATENCION: No sueltes el boton al menos hasta que empiece a borrar la memoria externa (cuando pone \"Erasing xxxx bytes...\" en la pantalla)\e[0m"
+        echo -e "\e[1;31mEnciende la consola y entra al menu Retro-Go con los botones LEFT+GAME y dejala esperando en el listado de las roms.\e[0m"
+        echo ""
+        echo -e "\e[1;31mPara continuar con el proceso pulsa cualquier tecla...\e[0m"
         read -n 1 -s -r -p ""
-        cd /home/$usuario/gameandwatch/game-and-watch-retro-go
-        #make clean
-        make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=15 EXTFLASH_OFFSET=1048576 INTFLASH_BANK=2 GNW_TARGET=$consola COVERFLOW=$caratula flash
+        cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
+        make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=15 EXTFLASH_OFFSET=1048576 INTFLASH_BANK=2 GNW_TARGET=$consola COVERFLOW=$caratula flash_saves_erase
         cd -
-        echo " "
-        echo " "
-        read -n 1 -s -r -p "Proceso concluido. Presiona cualquier tecla para continuar."
-        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
-        --title "Instalar solo Retro-Go" \
-        --msgbox "Proceso realizado." 0 0
+        #sleep 5
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.3-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso realizado." 0 0
     else
-        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
-        --title "Instalar solo Retro-Go" \
-        --msgbox "Proceso cancelado." 0 0
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.3-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso cancelado." 0 0
     fi
-    ./scene/2.2.3-cfw-retro-go-16mb-$consola.sh
-    clear;;
-  7)clear
     ./scene/2.2.3-save-state-$consola.sh
-	clear
+    clear;;
 esac
 clear

--- a/scene/2.2.3-save-state-mario.sh
+++ b/scene/2.2.3-save-state-mario.sh
@@ -28,12 +28,12 @@ dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO
        --ok-label Apply \
        --cancel-label Exit \
        --menu "Selecciona con las flechas la opcion deseada:" 14 140 15 \
-          1 "Hacer backup de los save states existentes que hay en la G&W con chip de 16MB y CFW slim" \
-          2 "Restaurar los save states desde el pc a la G&W con chip de 16MB y CFW slim" \
-          3 "Borrar los saves states existentes en la G&W con chip de 16MB y CFW slim para dejarla limpia" \
-          4 "Hacer backup de los save states existentes que hay en la G&W con chip de 16MB y CFW full" \
-          5 "Restaurar los save states desde el pc a la G&W con chip de 16MB y CFW full" \
-          6 "Borrar los saves states existentes en la G&W con chip de 16MB y CFW full para dejarla limpia"   2>"${INPUT}"
+          1 "16MB - CFW slim: Hacer backup de los save states existentes que hay en la G&W" \
+          2 "16MB - CFW slim: Restaurar los save states desde el pc a la G&W" \
+          3 "16MB - CFW slim: Borrar los saves states existentes en la G&W para dejarla limpia" \
+          4 "16MB - CFW full: Hacer backup de los save states existentes que hay en la G&W" \
+          5 "16MB - CFW full: Restaurar los save states desde el pc a la G&W" \
+          6 "16MB - CFW full: Borrar los saves states existentes en la G&W para dejarla limpia"   2>"${INPUT}"
 menuitem=$(<"${INPUT}")
 case $menuitem in
   1)clear

--- a/scene/2.2.3-save-state-mario.sh
+++ b/scene/2.2.3-save-state-mario.sh
@@ -15,12 +15,13 @@ dialog --backtitle "G&W $consola - Utilidades de flasheo" \
 --ok-label Apply \
 --cancel-label Exit \
 --menu "Selecciona con las flechas la opcion deseada:" 15 140 15 \
-   1 "CFW \"slim\" con los parametros para 16MB" \
+   1 "prueba" \
    2 "Compilar Retro-Go para CFW \"slim\" y parametros 16MB" \
    3 "Flashear Retro-Go para CFW \"slim\" y parametros 16MB" \
    4 "CFW \"full\" con los parametros para 16MB" \
    5 "Compilar Retro-Go para CFW \"full\" y parametros 16MB" \
-   6 "Flashear Retro-Go para CFW \"full\" y parametros 16MB" 2>"${INPUT}"
+   6 "Flashear Retro-Go para CFW \"full\" y parametros 16MB" \
+   7 "Descarga y restauracion de saves-states con parametros 16MB"   2>"${INPUT}"
 menuitem=$(<"${INPUT}")
 case $menuitem in
   1)clear
@@ -249,5 +250,8 @@ case $menuitem in
     fi
     ./scene/2.2.3-cfw-retro-go-16mb-$consola.sh
     clear;;
+  7)clear
+    ./scene/2.2.3-save-state-$consola.sh
+	clear
 esac
 clear

--- a/scene/2.2.3-save-state-mario.sh
+++ b/scene/2.2.3-save-state-mario.sh
@@ -4,7 +4,7 @@
 INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="mario"
-proc="4"
+proc="6"
 caratula="0"
 
 clear
@@ -27,7 +27,13 @@ dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO
        --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
        --ok-label Apply \
        --cancel-label Exit \
-       --menu "Selecciona con las flechas la opcion deseada:" 14 140 15 \
+       --menu "
+Usuario actual: $usuario
+Consola seleccionada: $consola
+Opcion caratulas: $caratula (0=NO y 1=SI)
+Save states: /home/$usuario/game-and-watch-retro-go/save_states/
+
+Selecciona con las flechas la opcion deseada:" 0 0 0 \
           1 "16MB - CFW slim: Hacer backup de los save states existentes que hay en la G&W" \
           2 "16MB - CFW slim: Restaurar los save states desde el pc a la G&W" \
           3 "16MB - CFW slim: Borrar los saves states existentes en la G&W para dejarla limpia" \

--- a/scene/2.2.3-save-state-zelda.sh
+++ b/scene/2.2.3-save-state-zelda.sh
@@ -4,7 +4,7 @@
 INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="zelda"
-proc="4"
+proc="6"
 caratula="0"
 
 clear
@@ -27,7 +27,13 @@ dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO
        --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
        --ok-label Apply \
        --cancel-label Exit \
-       --menu "Selecciona con las flechas la opcion deseada:" 12 140 15 \
+       --menu "
+Usuario actual: $usuario
+Consola seleccionada: $consola
+Opcion caratulas: $caratula (0=NO y 1=SI)
+Save states: /home/$usuario/game-and-watch-retro-go/save_states/
+
+Selecciona con las flechas la opcion deseada:" 0 0 0 \
           1 "Hacer backup de los save states existentes que hay en la G&W con chip de 16MB" \
           2 "Restaurar los save states desde el pc a la G&W con chip de 16MB" \
           3 "Borrar los saves states existentes en la G&W con chip de 16MB para dejarla limpia"   2>"${INPUT}"

--- a/scene/2.2.3-save-state-zelda.sh
+++ b/scene/2.2.3-save-state-zelda.sh
@@ -5,7 +5,7 @@ INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="zelda"
 proc="4"
-caratula="1"
+caratula="0"
 
 clear
 dpkg -s libncurses5 > libncurses5.txt
@@ -47,7 +47,8 @@ case $menuitem in
         cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
         make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=12 EXTFLASH_OFFSET=4194304 INTFLASH_BANK=2 GNW_TARGET=$consola COVERFLOW=$caratula flash_saves_backup
         cd -
-        #sleep 5
+        echo -e "\e[1;31mPulsa cualquier tecla para continuar...\e[0m"
+        read -n 1 -s -r -p ""
         dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.3-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
                --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
                --msgbox "Proceso realizado. Save states descargados en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" 0 0
@@ -56,7 +57,7 @@ case $menuitem in
                --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
                --msgbox "Proceso cancelado." 0 0
     fi
-    ./scene/2.2.4-save-state-$consola.sh
+    ./scene/2.2.3-save-state-$consola.sh
     clear;;
   2)clear
     dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.3-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
@@ -72,7 +73,8 @@ case $menuitem in
         cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
         make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=12 EXTFLASH_OFFSET=4194304 INTFLASH_BANK=2 GNW_TARGET=$consola COVERFLOW=$caratula flash_saves_restore
         cd -
-        #sleep 5
+        echo -e "\e[1;31mPulsa cualquier tecla para continuar...\e[0m"
+        read -n 1 -s -r -p ""
         dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.3-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
                --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
                --msgbox "Proceso realizado." 0 0
@@ -81,7 +83,7 @@ case $menuitem in
                --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
                --msgbox "Proceso cancelado." 0 0
     fi
-    ./scene/2.2.4-save-state-$consola.sh
+    ./scene/2.2.3-save-state-$consola.sh
     clear;;
   3)clear
     dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.3-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
@@ -97,7 +99,8 @@ case $menuitem in
         cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
         make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=12 EXTFLASH_OFFSET=4194304 INTFLASH_BANK=2 GNW_TARGET=$consola COVERFLOW=$caratula flash_saves_erase
         cd -
-        #sleep 5
+        echo -e "\e[1;31mPulsa cualquier tecla para continuar...\e[0m"
+        read -n 1 -s -r -p ""
         dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.3-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
                --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
                --msgbox "Proceso realizado." 0 0
@@ -106,7 +109,7 @@ case $menuitem in
                --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
                --msgbox "Proceso cancelado." 0 0
     fi
-    ./scene/2.2.4-save-state-$consola.sh
+    ./scene/2.2.3-save-state-$consola.sh
     clear;;
 esac
 clear

--- a/scene/2.2.3-save-state-zelda.sh
+++ b/scene/2.2.3-save-state-zelda.sh
@@ -4,7 +4,7 @@
 INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="zelda"
-proc="6"
+proc="4"
 caratula="0"
 
 clear

--- a/scene/2.2.3-save-state-zelda.sh
+++ b/scene/2.2.3-save-state-zelda.sh
@@ -5,12 +5,12 @@ INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="zelda"
 proc="4"
-caratula="0"
+caratula="1"
 
 #dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.3-cfw-retro-go-16mb-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
 #--title "G&W menu de flasheo $consola 16MB" \
 #--msgbox "ATENCION:\n\n\nCFW \"slim\" significa que no habra cancion de mario, no habra imagenes a la hora de dormir, se comprimira el resto del firm y se usara un flash interno indocumentado que requiere el openocd modificado. Esto permite que todo el firmware funcione sin utilizar ningún flash externo.\n\nCFW \"NO slim\" significa que se flasheara todo el firmware completo por lo que se usará parte de la flash externa con lo cual que se podran meter menos roms.\nPor contra se obtienen ciertos beneficios que son: tener la cancion de mario, las imagenes de dormir y se gestionarán mejor la configuracion y los highscores porque con CFW \"slim\" se pierden cuando la bateria esta baja o desenchufada" 0 0
-dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.3-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
 --title "G&W CFW + Retro-Go 16MB /// INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Roms en /home/$usuario/game-and-watch-retro-go/roms/" \
 --ok-label Apply \
 --cancel-label Exit \

--- a/scene/2.2.3-save-state-zelda.sh
+++ b/scene/2.2.3-save-state-zelda.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+#By julenvitoria
+
+INPUT=/tmp/$MENU.sh.$$
+usuario="kde"
+consola="zelda"
+proc="4"
+caratula="0"
+
+#dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.3-cfw-retro-go-16mb-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+#--title "G&W menu de flasheo $consola 16MB" \
+#--msgbox "ATENCION:\n\n\nCFW \"slim\" significa que no habra cancion de mario, no habra imagenes a la hora de dormir, se comprimira el resto del firm y se usara un flash interno indocumentado que requiere el openocd modificado. Esto permite que todo el firmware funcione sin utilizar ningún flash externo.\n\nCFW \"NO slim\" significa que se flasheara todo el firmware completo por lo que se usará parte de la flash externa con lo cual que se podran meter menos roms.\nPor contra se obtienen ciertos beneficios que son: tener la cancion de mario, las imagenes de dormir y se gestionarán mejor la configuracion y los highscores porque con CFW \"slim\" se pierden cuando la bateria esta baja o desenchufada" 0 0
+dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+--title "G&W CFW + Retro-Go 16MB /// INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Roms en /home/$usuario/game-and-watch-retro-go/roms/" \
+--ok-label Apply \
+--cancel-label Exit \
+--menu "Selecciona con las flechas la opcion deseada:" 15 140 15 \
+   1 "CFW con los parametros para 16MB" \
+   2 "Compilar Retro-Go para CFW y parametros 16MB" \
+   3 "Flashear Retro-Go para CFW y parametros 16MB" 2>"${INPUT}"
+menuitem=$(<"${INPUT}")
+case $menuitem in
+  1)clear
+    dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+    --title "Instalar CFW slim en G&W $consola con 16MB" \
+    --yesno "Se recomienda realizar el proceso con la batería cargada al 100% para evitar problemas. Este proceso es solamente para una consola con el chip de 16MB instalado.\n\n¡¡¡ATENCION!!!\nSI SE TIENE DIFERENTE CANTIDAD DE MEMORIA CANCELAR EL PROCESO y una vez vuelto al menu seleccionar el correcto.\n\nSe flasheara un custom firmware que consta del menu original de la consola ademas del emulador Retro-Go. El emulador aparecera al realizar el combo de botones \"LEFT\" + \"GAME\". Las roms que existan en /home/$usuario/game-and-watch-retro-go/roms/ tambien se subiran a la consola ¿Deseas continuar?" 0 0
+    ans=$?
+    if [ $ans -eq 0 ]; then
+        clear
+        if [ -f /home/$usuario/gameandwatch/game-and-watch-backup/backups/flash_backup_$consola.bin ]; then
+            echo "flash_backup_$consola.bin encontrado"
+            sleep 0.5
+            if [ -f /home/$usuario/gameandwatch/game-and-watch-backup/backups/internal_flash_backup_$consola.bin ]; then
+                echo "internal_flash_backup_$consola.bin encontrado"
+                sleep 0.5
+                cp /home/$usuario/gameandwatch/game-and-watch-backup/backups/flash_backup_$consola.bin /home/$usuario/gameandwatch/game-and-watch-patch
+                cp /home/$usuario/gameandwatch/game-and-watch-backup/backups/internal_flash_backup_$consola.bin /home/$usuario/gameandwatch/game-and-watch-patch
+                echo " "
+                echo "Se han copiado los archivos de la flash interna y externa"
+                echo " "
+                echo " "
+                echo "Proceso 1/2 concluido."
+                echo " "
+                echo -e "\e[1;34mSi ya has ejecutado esta opcion anteriormente y algo ha salido mal desmonta la consola y vuelve a ejecutar esta\e[0m"
+                echo -e "\e[1;34mopcion y, al llegar a este punto, desconecta la bateria y vuelve a conectarla antes de realizar lo siguiente.\e[0m"
+                echo " "
+                echo " "
+                echo -e "\e[1;31mPulsa y manten pulsado el boton de encendido y justo despues pulsa cualquier tecla para continuar...\e[0m"
+                read -n 1 -s -r -p ""
+                clear
+                cd /home/$usuario/gameandwatch/game-and-watch-patch
+                make clean
+                make PATCH_PARAMS="--device=$consola" flash_patched
+                sleep 0.5
+                make reset
+                cd -
+                echo " "
+                echo " "
+                echo "Proceso 2/2 concluido."
+                read -n 1 -s -r -p "Presiona cualquier tecla para continuar"
+            else
+                echo "No se ha encontrado internal_flash_backup_$consola.bin, cancelando..."
+                sleep 2
+            fi
+        else
+            echo "No se ha encontrado flash_backup_$consola.bin, cancelando..."
+            sleep 2
+        fi
+        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+        --title "Instalar CFW en G&W $consola con 16MB" \
+        --msgbox "Proceso realizado." 0 0
+    else
+            dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+            --title "Instalar firmware original + Retro-Go  en consola con 16MB" \
+            --msgbox "Proceso cancelado." 0 0
+    fi
+    ./scene/2.2.3-cfw-retro-go-16mb-$consola.sh
+    clear;;
+  2)clear
+    dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+    --title "Compilar Retro-Go" \
+    --yesno "Se procedera a compilar RetroGo con los parametros de memoria de 16mb pata CFW slim y se incluiran las roms que existan en /home/$usuario/game-and-watch-retro-go/roms/. ¿Deseas continuar?" 0 0
+    ans=$?
+    if [ $ans -eq 0 ]; then
+        clear
+        cd /home/$usuario/gameandwatch/game-and-watch-retro-go
+        make clean
+        make -j$proc EXTFLASH_SIZE_MB=12 EXTFLASH_OFFSET=4194304 INTFLASH_BANK=2 GNW_TARGET=$consola COVERFLOW=$caratula
+        cd -
+        echo " "
+        echo " "
+        read -n 1 -s -r -p "Proceso concluido. Presiona cualquier tecla para continuar."
+        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+        --title "Compilar Retro-Go" \
+        --msgbox "Proceso realizado." 0 0
+    else
+        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+        --title "Compilar Retro-Go" \
+        --msgbox "Proceso cancelado." 0 0
+    fi
+    ./scene/2.2.3-cfw-retro-go-16mb-$consola.sh
+    clear;;
+  3)clear
+    dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+    --title "Instalar Retro-Go" \
+    --yesno "Se recomienda realizar el proceso con la batería cargada al 100% para evitar problemas. Se flasheara solamente el emulador Retro-Go por lo que no tendremos el menu original. Las roms que existan en /home/$usuario/game-and-watch-retro-go/roms/ tambien se subiran a la consola." 0 0
+    ans=$?
+    if [ $ans -eq 0 ]; then
+        clear
+        echo " "
+        echo -e "\e[1;34mSi ya has ejecutado esta opcion anteriormente y algo ha salido mal desmonta la consola y vuelve a ejecutar esta\e[0m"
+        echo -e "\e[1;34mopcion y, al llegar a este punto, desconecta la bateria y vuelve a conectarla antes de realizar lo siguiente.\e[0m"
+        echo " "
+        echo " "
+        echo -e "\e[0;32mSi durante el siguiente proceso nos dice que ha fallado el flasheo, que no puede conectar y nos pregunta si\e[0m"
+        echo -e "\e[0;32mvamos a hacer un power cycle (quitar bateria, reconectar y encender) pulsaremos el boton de encendido y lo \e[0m"
+        echo -e "\e[0;32mmantendremos pulsado unos segundos, le diremos que si con \"y\" (yes), entonces el proceso continuara.\e[0m"
+        echo -e "\e[1;31mPulsa y manten pulsado el boton de encendido y justo despues pulsa cualquier tecla para continuar...\nATENCION: No sueltes el boton al menos hasta que empiece a borrar la memoria externa (cuando pone \"Erasing xxxx bytes...\" en la pantalla)\e[0m"
+        read -n 1 -s -r -p ""
+        cd /home/$usuario/gameandwatch/game-and-watch-retro-go
+        #make clean
+        make -j$proc EXTFLASH_SIZE_MB=12 EXTFLASH_OFFSET=4194304 INTFLASH_BANK=2 GNW_TARGET=$consola COVERFLOW=$caratula flash
+        cd -
+        echo " "
+        echo " "
+        read -n 1 -s -r -p "Proceso concluido. Presiona cualquier tecla para continuar."
+        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+        --title "Instalar solo Retro-Go" \
+        --msgbox "Proceso realizado." 0 0
+    else
+        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+        --title "Instalar solo Retro-Go" \
+        --msgbox "Proceso cancelado." 0 0
+    fi
+    ./scene/2.2.3-cfw-retro-go-16mb-$consola.sh
+    clear;;
+esac
+clear

--- a/scene/2.2.3-save-state-zelda.sh
+++ b/scene/2.2.3-save-state-zelda.sh
@@ -7,136 +7,106 @@ consola="zelda"
 proc="4"
 caratula="1"
 
-#dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.3-cfw-retro-go-16mb-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
-#--title "G&W menu de flasheo $consola 16MB" \
-#--msgbox "ATENCION:\n\n\nCFW \"slim\" significa que no habra cancion de mario, no habra imagenes a la hora de dormir, se comprimira el resto del firm y se usara un flash interno indocumentado que requiere el openocd modificado. Esto permite que todo el firmware funcione sin utilizar ningún flash externo.\n\nCFW \"NO slim\" significa que se flasheara todo el firmware completo por lo que se usará parte de la flash externa con lo cual que se podran meter menos roms.\nPor contra se obtienen ciertos beneficios que son: tener la cancion de mario, las imagenes de dormir y se gestionarán mejor la configuracion y los highscores porque con CFW \"slim\" se pierden cuando la bateria esta baja o desenchufada" 0 0
+clear
+dpkg -s libncurses5 > libncurses5.txt
+if grep "install ok installed" ./libncurses5.txt ; then
+        echo "Encontrado paquete libncurses5, se prosigue..."
+        sleep 0.5
+else
+        echo "No encontrado paquete dialog necesario, instalando..."
+        echo " "
+        sudo apt install -y libncurses5
+        echo " "
+        echo "Instalado!!"
+        sleep 0.5
+fi
+
 dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.3-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
---title "G&W CFW + Retro-Go 16MB /// INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Roms en /home/$usuario/game-and-watch-retro-go/roms/" \
---ok-label Apply \
---cancel-label Exit \
---menu "Selecciona con las flechas la opcion deseada:" 15 140 15 \
-   1 "prueba" \
-   2 "Compilar Retro-Go para CFW y parametros 16MB" \
-   3 "Flashear Retro-Go para CFW y parametros 16MB" \
-   4 "Descarga y restauracion de saves-states con parametros 16MB"   2>"${INPUT}"
+       --msgbox "G&W Utilidad para backup, resturacion y borrado de save states. Una vez descargados los save states estan ubicados en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" 0 0
+dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.3-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+       --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+       --ok-label Apply \
+       --cancel-label Exit \
+       --menu "Selecciona con las flechas la opcion deseada:" 12 140 15 \
+          1 "Hacer backup de los save states existentes que hay en la G&W con chip de 16MB" \
+          2 "Restaurar los save states desde el pc a la G&W con chip de 16MB" \
+          3 "Borrar los saves states existentes en la G&W con chip de 16MB para dejarla limpia"   2>"${INPUT}"
 menuitem=$(<"${INPUT}")
 case $menuitem in
   1)clear
-    dialog --backtitle "G&W $consola - Utilidades de flasheo" \
-    --title "Instalar CFW slim en G&W $consola con 16MB" \
-    --yesno "Se recomienda realizar el proceso con la batería cargada al 100% para evitar problemas. Este proceso es solamente para una consola con el chip de 16MB instalado.\n\n¡¡¡ATENCION!!!\nSI SE TIENE DIFERENTE CANTIDAD DE MEMORIA CANCELAR EL PROCESO y una vez vuelto al menu seleccionar el correcto.\n\nSe flasheara un custom firmware que consta del menu original de la consola ademas del emulador Retro-Go. El emulador aparecera al realizar el combo de botones \"LEFT\" + \"GAME\". Las roms que existan en /home/$usuario/game-and-watch-retro-go/roms/ tambien se subiran a la consola ¿Deseas continuar?" 0 0
+    dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.3-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+           --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+           --yesno "¡¡¡ATENCION!!! El proceso de BACKUP de los save states puede llegar a tardar varios minutos dependiendo de la cantidad de roms que haya en la G&W y pararlo puede ocasionar errores. ¿Deseas continuar?" 0 0
     ans=$?
     if [ $ans -eq 0 ]; then
         clear
-        if [ -f /home/$usuario/gameandwatch/game-and-watch-backup/backups/flash_backup_$consola.bin ]; then
-            echo "flash_backup_$consola.bin encontrado"
-            sleep 0.5
-            if [ -f /home/$usuario/gameandwatch/game-and-watch-backup/backups/internal_flash_backup_$consola.bin ]; then
-                echo "internal_flash_backup_$consola.bin encontrado"
-                sleep 0.5
-                cp /home/$usuario/gameandwatch/game-and-watch-backup/backups/flash_backup_$consola.bin /home/$usuario/gameandwatch/game-and-watch-patch
-                cp /home/$usuario/gameandwatch/game-and-watch-backup/backups/internal_flash_backup_$consola.bin /home/$usuario/gameandwatch/game-and-watch-patch
-                echo " "
-                echo "Se han copiado los archivos de la flash interna y externa"
-                echo " "
-                echo " "
-                echo "Proceso 1/2 concluido."
-                echo " "
-                echo -e "\e[1;34mSi ya has ejecutado esta opcion anteriormente y algo ha salido mal desmonta la consola y vuelve a ejecutar esta\e[0m"
-                echo -e "\e[1;34mopcion y, al llegar a este punto, desconecta la bateria y vuelve a conectarla antes de realizar lo siguiente.\e[0m"
-                echo " "
-                echo " "
-                echo -e "\e[1;31mPulsa y manten pulsado el boton de encendido y justo despues pulsa cualquier tecla para continuar...\e[0m"
-                read -n 1 -s -r -p ""
-                clear
-                cd /home/$usuario/gameandwatch/game-and-watch-patch
-                make clean
-                make PATCH_PARAMS="--device=$consola" flash_patched
-                sleep 0.5
-                make reset
-                cd -
-                echo " "
-                echo " "
-                echo "Proceso 2/2 concluido."
-                read -n 1 -s -r -p "Presiona cualquier tecla para continuar"
-            else
-                echo "No se ha encontrado internal_flash_backup_$consola.bin, cancelando..."
-                sleep 2
-            fi
-        else
-            echo "No se ha encontrado flash_backup_$consola.bin, cancelando..."
-            sleep 2
-        fi
-        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
-        --title "Instalar CFW en G&W $consola con 16MB" \
-        --msgbox "Proceso realizado." 0 0
+        echo -e "\e[1;31mEnciende la consola y entra al menu Retro-Go con los botones LEFT+GAME y dejala esperando en el listado de las roms.\e[0m"
+        echo ""
+        echo -e "\e[1;31mPara continuar con el proceso pulsa cualquier tecla...\e[0m"
+        read -n 1 -s -r -p ""
+        cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
+        make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=12 EXTFLASH_OFFSET=4194304 INTFLASH_BANK=2 GNW_TARGET=$consola COVERFLOW=$caratula flash_saves_backup
+        cd -
+        #sleep 5
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.3-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso realizado. Save states descargados en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" 0 0
     else
-            dialog --backtitle "G&W $consola - Utilidades de flasheo" \
-            --title "Instalar firmware original + Retro-Go  en consola con 16MB" \
-            --msgbox "Proceso cancelado." 0 0
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.3-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso cancelado." 0 0
     fi
-    ./scene/2.2.3-cfw-retro-go-16mb-$consola.sh
+    ./scene/2.2.4-save-state-$consola.sh
     clear;;
   2)clear
-    dialog --backtitle "G&W $consola - Utilidades de flasheo" \
-    --title "Compilar Retro-Go" \
-    --yesno "Se procedera a compilar RetroGo con los parametros de memoria de 16mb pata CFW slim y se incluiran las roms que existan en /home/$usuario/game-and-watch-retro-go/roms/. ¿Deseas continuar?" 0 0
+    dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.3-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+           --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+           --yesno "¡¡¡ATENCION!!! El proceso RESTAURACION de los save states puede llegar a tardar varios minutos dependiendo de la cantidad de roms que haya en la G&W y pararlo puede ocasionar errores. ¿Deseas continuar?" 0 0
     ans=$?
     if [ $ans -eq 0 ]; then
         clear
-        cd /home/$usuario/gameandwatch/game-and-watch-retro-go
-        make clean
-        make -j$proc EXTFLASH_SIZE_MB=12 EXTFLASH_OFFSET=4194304 INTFLASH_BANK=2 GNW_TARGET=$consola COVERFLOW=$caratula
+        echo -e "\e[1;31mEnciende la consola y entra al menu Retro-Go con los botones LEFT+GAME y dejala esperando en el listado de las roms.\e[0m"
+        echo ""
+        echo -e "\e[1;31mPara continuar con el proceso pulsa cualquier tecla...\e[0m"
+        read -n 1 -s -r -p ""
+        cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
+        make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=12 EXTFLASH_OFFSET=4194304 INTFLASH_BANK=2 GNW_TARGET=$consola COVERFLOW=$caratula flash_saves_restore
         cd -
-        echo " "
-        echo " "
-        read -n 1 -s -r -p "Proceso concluido. Presiona cualquier tecla para continuar."
-        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
-        --title "Compilar Retro-Go" \
-        --msgbox "Proceso realizado." 0 0
+        #sleep 5
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.3-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso realizado." 0 0
     else
-        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
-        --title "Compilar Retro-Go" \
-        --msgbox "Proceso cancelado." 0 0
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.3-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso cancelado." 0 0
     fi
-    ./scene/2.2.3-cfw-retro-go-16mb-$consola.sh
+    ./scene/2.2.4-save-state-$consola.sh
     clear;;
   3)clear
-    dialog --backtitle "G&W $consola - Utilidades de flasheo" \
-    --title "Instalar Retro-Go" \
-    --yesno "Se recomienda realizar el proceso con la batería cargada al 100% para evitar problemas. Se flasheara solamente el emulador Retro-Go por lo que no tendremos el menu original. Las roms que existan en /home/$usuario/game-and-watch-retro-go/roms/ tambien se subiran a la consola." 0 0
+    dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.3-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+           --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+           --yesno "¡¡¡ATENCION!!! El proceso BORRAR los save states puede llegar a tardar varios minutos dependiendo de la cantidad de roms que haya en la G&W y pararlo puede ocasionar errores. ¿Deseas continuar?" 0 0
     ans=$?
     if [ $ans -eq 0 ]; then
         clear
-        echo " "
-        echo -e "\e[1;34mSi ya has ejecutado esta opcion anteriormente y algo ha salido mal desmonta la consola y vuelve a ejecutar esta\e[0m"
-        echo -e "\e[1;34mopcion y, al llegar a este punto, desconecta la bateria y vuelve a conectarla antes de realizar lo siguiente.\e[0m"
-        echo " "
-        echo " "
-        echo -e "\e[0;32mSi durante el siguiente proceso nos dice que ha fallado el flasheo, que no puede conectar y nos pregunta si\e[0m"
-        echo -e "\e[0;32mvamos a hacer un power cycle (quitar bateria, reconectar y encender) pulsaremos el boton de encendido y lo \e[0m"
-        echo -e "\e[0;32mmantendremos pulsado unos segundos, le diremos que si con \"y\" (yes), entonces el proceso continuara.\e[0m"
-        echo -e "\e[1;31mPulsa y manten pulsado el boton de encendido y justo despues pulsa cualquier tecla para continuar...\nATENCION: No sueltes el boton al menos hasta que empiece a borrar la memoria externa (cuando pone \"Erasing xxxx bytes...\" en la pantalla)\e[0m"
+        echo -e "\e[1;31mEnciende la consola y entra al menu Retro-Go con los botones LEFT+GAME y dejala esperando en el listado de las roms.\e[0m"
+        echo ""
+        echo -e "\e[1;31mPara continuar con el proceso pulsa cualquier tecla...\e[0m"
         read -n 1 -s -r -p ""
-        cd /home/$usuario/gameandwatch/game-and-watch-retro-go
-        #make clean
-        make -j$proc EXTFLASH_SIZE_MB=12 EXTFLASH_OFFSET=4194304 INTFLASH_BANK=2 GNW_TARGET=$consola COVERFLOW=$caratula flash
+        cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
+        make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=12 EXTFLASH_OFFSET=4194304 INTFLASH_BANK=2 GNW_TARGET=$consola COVERFLOW=$caratula flash_saves_erase
         cd -
-        echo " "
-        echo " "
-        read -n 1 -s -r -p "Proceso concluido. Presiona cualquier tecla para continuar."
-        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
-        --title "Instalar solo Retro-Go" \
-        --msgbox "Proceso realizado." 0 0
+        #sleep 5
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.3-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso realizado." 0 0
     else
-        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
-        --title "Instalar solo Retro-Go" \
-        --msgbox "Proceso cancelado." 0 0
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.3-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso cancelado." 0 0
     fi
-    ./scene/2.2.3-cfw-retro-go-16mb-$consola.sh
+    ./scene/2.2.4-save-state-$consola.sh
     clear;;
-  4)clear
-    ./scene/2.2.3-save-state-$consola.sh
-	clear
 esac
 clear

--- a/scene/2.2.3-save-state-zelda.sh
+++ b/scene/2.2.3-save-state-zelda.sh
@@ -15,9 +15,10 @@ dialog --backtitle "G&W $consola - Utilidades de flasheo" \
 --ok-label Apply \
 --cancel-label Exit \
 --menu "Selecciona con las flechas la opcion deseada:" 15 140 15 \
-   1 "CFW con los parametros para 16MB" \
+   1 "prueba" \
    2 "Compilar Retro-Go para CFW y parametros 16MB" \
-   3 "Flashear Retro-Go para CFW y parametros 16MB" 2>"${INPUT}"
+   3 "Flashear Retro-Go para CFW y parametros 16MB" \
+   4 "Descarga y restauracion de saves-states con parametros 16MB"   2>"${INPUT}"
 menuitem=$(<"${INPUT}")
 case $menuitem in
   1)clear
@@ -134,5 +135,8 @@ case $menuitem in
     fi
     ./scene/2.2.3-cfw-retro-go-16mb-$consola.sh
     clear;;
+  4)clear
+    ./scene/2.2.3-save-state-$consola.sh
+	clear
 esac
 clear

--- a/scene/2.2.4-cfw-retro-go-64mb-mario.sh
+++ b/scene/2.2.4-cfw-retro-go-64mb-mario.sh
@@ -5,7 +5,7 @@ INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="mario"
 proc="4"
-caratula="0"
+caratula="1"
 
 dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.4-cfw-retro-go-64mb-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
 --title "G&W CFW + Retro-Go 64MB /// INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Roms en /home/$usuario/game-and-watch-retro-go/roms/" \
@@ -133,6 +133,7 @@ case $menuitem in
     clear;;
   4)clear
     ./scene/2.2.4-save-state-$consola.sh
-	clear
+    ./scene/2.2.4-cfw-retro-go-64mb-$consola.sh
+	clear;;
 esac
 clear

--- a/scene/2.2.4-cfw-retro-go-64mb-mario.sh
+++ b/scene/2.2.4-cfw-retro-go-64mb-mario.sh
@@ -4,7 +4,7 @@
 INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="mario"
-proc="6"
+proc="4"
 caratula="0"
 
 dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.4-cfw-retro-go-64mb-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \

--- a/scene/2.2.4-cfw-retro-go-64mb-mario.sh
+++ b/scene/2.2.4-cfw-retro-go-64mb-mario.sh
@@ -5,7 +5,7 @@ INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="mario"
 proc="4"
-caratula="1"
+caratula="0"
 
 dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.4-cfw-retro-go-64mb-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
 --title "G&W CFW + Retro-Go 64MB /// INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Roms en /home/$usuario/game-and-watch-retro-go/roms/" \

--- a/scene/2.2.4-cfw-retro-go-64mb-mario.sh
+++ b/scene/2.2.4-cfw-retro-go-64mb-mario.sh
@@ -18,12 +18,17 @@ Opcion caratulas: $caratula (0=NO y 1=SI)
 Roms: /home/$usuario/game-and-watch-retro-go/roms/
 
 Selecciona con las flechas la opcion deseada:" 0 0 0 \
+   H "Herramientas y utilidades" \
    1 "CFW con los parametros para 64MB" \
    2 "Compilar Retro-Go con los parametros para 64MB" \
    3 "Flashear Retro-Go con los parametros para 64MB" \
    4 "Descarga y restauracion de saves-states con parametros 64MB"   2>"${INPUT}"
 menuitem=$(<"${INPUT}")
 case $menuitem in
+  H)clear
+    ./scene/2.2.H-opcion-herramientas.sh
+    ./scene/2.2.4-cfw-retro-go-64mb-$consola.sh
+    clear;;
   1)clear
     dialog --backtitle "G&W $consola - Utilidades de flasheo" \
     --title "Instalar Retro-Go en consola G&W $consola con 64MB" \

--- a/scene/2.2.4-cfw-retro-go-64mb-mario.sh
+++ b/scene/2.2.4-cfw-retro-go-64mb-mario.sh
@@ -4,14 +4,20 @@
 INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="mario"
-proc="4"
+proc="6"
 caratula="0"
 
 dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.4-cfw-retro-go-64mb-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
 --title "G&W CFW + Retro-Go 64MB /// INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Roms en /home/$usuario/game-and-watch-retro-go/roms/" \
 --ok-label Apply \
 --cancel-label Exit \
---menu "Selecciona con las flechas la opcion deseada:" 12 140 15 \
+--menu "
+Usuario actual: $usuario
+Consola seleccionada: $consola
+Opcion caratulas: $caratula (0=NO y 1=SI)
+Roms: /home/$usuario/game-and-watch-retro-go/roms/
+
+Selecciona con las flechas la opcion deseada:" 0 0 0 \
    1 "CFW con los parametros para 64MB" \
    2 "Compilar Retro-Go con los parametros para 64MB" \
    3 "Flashear Retro-Go con los parametros para 64MB" \

--- a/scene/2.2.4-cfw-retro-go-64mb-mario.sh
+++ b/scene/2.2.4-cfw-retro-go-64mb-mario.sh
@@ -14,7 +14,8 @@ dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO
 --menu "Selecciona con las flechas la opcion deseada:" 12 140 15 \
    1 "CFW con los parametros para 64MB" \
    2 "Compilar Retro-Go con los parametros para 64MB" \
-   3 "Flashear Retro-Go con los parametros para 64MB" 2>"${INPUT}"
+   3 "Flashear Retro-Go con los parametros para 64MB" \
+   4 "Descarga y restauracion de saves-states con parametros 64MB"   2>"${INPUT}"
 menuitem=$(<"${INPUT}")
 case $menuitem in
   1)clear
@@ -130,5 +131,8 @@ case $menuitem in
     fi
     ./scene/2.2.4-cfw-retro-go-64mb-$consola.sh
     clear;;
+  4)clear
+    ./scene/2.2.4-save-state-$consola.sh
+	clear
 esac
 clear

--- a/scene/2.2.4-cfw-retro-go-64mb-zelda.sh
+++ b/scene/2.2.4-cfw-retro-go-64mb-zelda.sh
@@ -5,7 +5,7 @@ INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="zelda"
 proc="4"
-caratula="0"
+caratula="1"
 
 dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.4-cfw-retro-go-64mb-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
 --title "G&W CFW + Retro-Go 64MB /// INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Roms en /home/$usuario/game-and-watch-retro-go/roms/" \
@@ -131,6 +131,7 @@ case $menuitem in
     clear;;
   4)clear
     ./scene/2.2.4-save-state-$consola.sh
-	clear
+    ./scene/2.2.4-cfw-retro-go-64mb-$consola.sh
+	clear;;
 esac
 clear

--- a/scene/2.2.4-cfw-retro-go-64mb-zelda.sh
+++ b/scene/2.2.4-cfw-retro-go-64mb-zelda.sh
@@ -14,7 +14,8 @@ dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO
 --menu "Selecciona con las flechas la opcion deseada:" 12 140 15 \
    1 "CFW con los parametros para 64MB" \
    2 "Compilar Retro-Go con los parametros para 64MB" \
-   3 "Flashear Retro-Go con los parametros para 64MB" 2>"${INPUT}"
+   3 "Flashear Retro-Go con los parametros para 64MB" \
+   4 "Descarga y restauracion de saves-states con parametros 64MB"   2>"${INPUT}"
 menuitem=$(<"${INPUT}")
 case $menuitem in
   1)clear
@@ -128,5 +129,8 @@ case $menuitem in
     fi
     ./scene/2.2.4-cfw-retro-go-64mb-$consola.sh
     clear;;
+  4)clear
+    ./scene/2.2.4-save-state-$consola.sh
+	clear
 esac
 clear

--- a/scene/2.2.4-cfw-retro-go-64mb-zelda.sh
+++ b/scene/2.2.4-cfw-retro-go-64mb-zelda.sh
@@ -4,7 +4,7 @@
 INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="zelda"
-proc="6"
+proc="4"
 caratula="0"
 
 dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.4-cfw-retro-go-64mb-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
@@ -18,12 +18,17 @@ Opcion caratulas: $caratula (0=NO y 1=SI)
 Roms: /home/$usuario/game-and-watch-retro-go/roms/
 
 Selecciona con las flechas la opcion deseada:" 0 0 0 \
+   H "Herramientas y utilidades" \
    1 "CFW con los parametros para 64MB" \
    2 "Compilar Retro-Go con los parametros para 64MB" \
    3 "Flashear Retro-Go con los parametros para 64MB" \
    4 "Descarga y restauracion de saves-states con parametros 64MB"   2>"${INPUT}"
 menuitem=$(<"${INPUT}")
 case $menuitem in
+  H)clear
+    ./scene/2.2.H-opcion-herramientas.sh
+    ./scene/2.2.4-cfw-retro-go-64mb-$consola.sh
+    clear;;
   1)clear
     dialog --backtitle "G&W $consola - Utilidades de flasheo" \
     --title "Instalar Retro-Go en consola G&W $consola con 64MB" \

--- a/scene/2.2.4-cfw-retro-go-64mb-zelda.sh
+++ b/scene/2.2.4-cfw-retro-go-64mb-zelda.sh
@@ -4,14 +4,20 @@
 INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="zelda"
-proc="4"
+proc="6"
 caratula="0"
 
 dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.4-cfw-retro-go-64mb-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
 --title "G&W CFW + Retro-Go 64MB /// INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Roms en /home/$usuario/game-and-watch-retro-go/roms/" \
 --ok-label Apply \
 --cancel-label Exit \
---menu "Selecciona con las flechas la opcion deseada:" 12 140 15 \
+--menu "
+Usuario actual: $usuario
+Consola seleccionada: $consola
+Opcion caratulas: $caratula (0=NO y 1=SI)
+Roms: /home/$usuario/game-and-watch-retro-go/roms/
+
+Selecciona con las flechas la opcion deseada:" 0 0 0 \
    1 "CFW con los parametros para 64MB" \
    2 "Compilar Retro-Go con los parametros para 64MB" \
    3 "Flashear Retro-Go con los parametros para 64MB" \

--- a/scene/2.2.4-cfw-retro-go-64mb-zelda.sh
+++ b/scene/2.2.4-cfw-retro-go-64mb-zelda.sh
@@ -5,7 +5,7 @@ INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="zelda"
 proc="4"
-caratula="1"
+caratula="0"
 
 dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.4-cfw-retro-go-64mb-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
 --title "G&W CFW + Retro-Go 64MB /// INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Roms en /home/$usuario/game-and-watch-retro-go/roms/" \

--- a/scene/2.2.4-save-state-mario.sh
+++ b/scene/2.2.4-save-state-mario.sh
@@ -21,39 +21,91 @@ else
         sleep 0.5
 fi
 
-dialog --msgbox "G&W Utilidad para backup, resturacion y borrado de save states. Una vez descargados los save states estan ubicados en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" 0 0
 dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.4-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
---title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
---ok-label Apply \
---cancel-label Exit \
---menu "Selecciona con las flechas la opcion deseada:" 12 140 15 \
-   1 "Hacer backup de los save states existentes en la G&W" \
-   2 "Restaurar los save states desde el pc a la G&W " \
-   3 "Borrar los saves states existentes en la G&W para dejarla limpia"   2>"${INPUT}"
+       --msgbox "G&W Utilidad para backup, resturacion y borrado de save states. Una vez descargados los save states estan ubicados en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" 0 0
+dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.4-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+       --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+       --ok-label Apply \
+       --cancel-label Exit \
+       --menu "Selecciona con las flechas la opcion deseada:" 12 140 15 \
+          1 "Hacer backup de los save states existentes en la G&W" \
+          2 "Restaurar los save states desde el pc a la G&W " \
+          3 "Borrar los saves states existentes en la G&W para dejarla limpia"   2>"${INPUT}"
 menuitem=$(<"${INPUT}")
 case $menuitem in
   1)clear
-    cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
-	make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=63 EXTFLASH_OFFSET=1048576 INTFLASH_BANK=2 GNW_TARGET=$consola COVERFLOW=$caratula flash_saves_backup
-	cd -
-	sleep 5
-    dialog --msgbox "Save states descargados en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" 0 0
+    dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.4-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+           --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+           --yesno "¡¡¡ATENCION!!! El proceso de BACKUP de los save states puede llegar a tardar varios minutos dependiendo de la cantidad de roms que haya en la G&W y pararlo puede ocasionar errores. ¿Deseas continuar?" 0 0
+    ans=$?
+    if [ $ans -eq 0 ]; then
+        clear
+        echo -e "\e[1;31mEnciende la consola y entra al menu Retro-Go con los botones LEFT+GAME y dejala esperando en el listado de las roms.\e[0m"
+        echo ""
+        echo -e "\e[1;31mPara continuar con el proceso pulsa cualquier tecla...\e[0m"
+        read -n 1 -s -r -p ""
+        cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
+        make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=63 EXTFLASH_OFFSET=1048576 INTFLASH_BANK=2 GNW_TARGET=$consola COVERFLOW=$caratula flash_saves_backup
+        cd -
+        #sleep 5
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.4-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso realizado. Save states descargados en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" 0 0
+    else
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.4-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso cancelado." 0 0
+    fi
     ./scene/2.2.4-save-state-$consola.sh
     clear;;
   2)clear
-    cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
-	make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=63 EXTFLASH_OFFSET=1048576 INTFLASH_BANK=2 GNW_TARGET=$consola COVERFLOW=$caratula flash_saves_restore
-	cd -
-    sleep 5
-	dialog --msgbox "Proceso concluido..." 0 0; sleep 2
+    dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.4-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+           --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+           --yesno "¡¡¡ATENCION!!! El proceso RESTAURACION de los save states puede llegar a tardar varios minutos dependiendo de la cantidad de roms que haya en la G&W y pararlo puede ocasionar errores. ¿Deseas continuar?" 0 0
+    ans=$?
+    if [ $ans -eq 0 ]; then
+        clear
+        echo -e "\e[1;31mEnciende la consola y entra al menu Retro-Go con los botones LEFT+GAME y dejala esperando en el listado de las roms.\e[0m"
+        echo ""
+        echo -e "\e[1;31mPara continuar con el proceso pulsa cualquier tecla...\e[0m"
+        read -n 1 -s -r -p ""
+        cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
+        make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=63 EXTFLASH_OFFSET=1048576 INTFLASH_BANK=2 GNW_TARGET=$consola COVERFLOW=$caratula flash_saves_restore
+        cd -
+        #sleep 5
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.4-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso realizado." 0 0
+    else
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.4-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso cancelado." 0 0
+    fi
     ./scene/2.2.4-save-state-$consola.sh
     clear;;
   3)clear
-    cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
-	make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=63 EXTFLASH_OFFSET=1048576 INTFLASH_BANK=2 GNW_TARGET=$consola COVERFLOW=$caratula flash_saves_erase
-	cd -
-    sleep 5
-	dialog --msgbox "Proceso concluido..." 0 0; sleep 2
+    dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.4-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+           --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+           --yesno "¡¡¡ATENCION!!! El proceso BORRAR los save states puede llegar a tardar varios minutos dependiendo de la cantidad de roms que haya en la G&W y pararlo puede ocasionar errores. ¿Deseas continuar?" 0 0
+    ans=$?
+    if [ $ans -eq 0 ]; then
+        clear
+        echo -e "\e[1;31mEnciende la consola y entra al menu Retro-Go con los botones LEFT+GAME y dejala esperando en el listado de las roms.\e[0m"
+        echo ""
+        echo -e "\e[1;31mPara continuar con el proceso pulsa cualquier tecla...\e[0m"
+        read -n 1 -s -r -p ""
+        cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
+        make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=63 EXTFLASH_OFFSET=1048576 INTFLASH_BANK=2 GNW_TARGET=$consola COVERFLOW=$caratula flash_saves_erase
+        cd -
+        #sleep 5
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.4-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso realizado." 0 0
+    else
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.4-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso cancelado." 0 0
+    fi
     ./scene/2.2.4-save-state-$consola.sh
     clear;;
 esac

--- a/scene/2.2.4-save-state-mario.sh
+++ b/scene/2.2.4-save-state-mario.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+#By julenvitoria
+
+INPUT=/tmp/$MENU.sh.$$
+usuario="kde"
+consola="mario"
+proc="4"
+caratula="0"
+
+dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.4-cfw-retro-go-64mb-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+--title "G&W CFW + Retro-Go 64MB /// INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Roms en /home/$usuario/game-and-watch-retro-go/roms/" \
+--ok-label Apply \
+--cancel-label Exit \
+--menu "Selecciona con las flechas la opcion deseada:" 12 140 15 \
+   1 "CFW con los parametros para 64MB" \
+   2 "Compilar Retro-Go con los parametros para 64MB" \
+   3 "Flashear Retro-Go con los parametros para 64MB" 2>"${INPUT}"
+menuitem=$(<"${INPUT}")
+case $menuitem in
+  1)clear
+    dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+    --title "Instalar Retro-Go en consola G&W $consola con 64MB" \
+    --yesno "Se recomienda realizar el proceso con la batería cargada al 100% para evitar problemas. Este proceso es solamente para una consola con el chip de 64MB instalado.\n\n¡¡¡ATENCION!!!\nSI SE TIENE DIFERENTE CANTIDAD DE MEMORIA CANCELAR EL PROCESO y una vez vuelto al menu seleccionar el correcto.\n\nSe flasheara un custom firmware que consta del menu original de la consola ademas del acceso al emulador Retro-Go. El emulador aparecera al realizar el combo de botones \"LEFT\" + \"GAME\". ¿Deseas continuar?" 0 0
+    ans=$?
+    if [ $ans -eq 0 ]; then
+        clear
+        if [ -f /home/$usuario/gameandwatch/game-and-watch-backup/backups/flash_backup_$consola.bin ]; then
+            echo "flash_backup_$consola.bin encontrado"
+            sleep 0.5
+            if [ -f /home/$usuario/gameandwatch/game-and-watch-backup/backups/internal_flash_backup_$consola.bin ]; then
+                echo "internal_flash_backup_$consola.bin encontrado"
+                sleep 0.5
+                cp /home/$usuario/gameandwatch/game-and-watch-backup/backups/flash_backup_$consola.bin /home/$usuario/gameandwatch/game-and-watch-patch
+                cp /home/$usuario/gameandwatch/game-and-watch-backup/backups/internal_flash_backup_$consola.bin /home/$usuario/gameandwatch/game-and-watch-patch
+                echo " "
+                echo "Se han copiado los archivos de la flash interna y externa"
+                echo " "
+                echo " "
+                echo "Proceso 1/2 concluido."
+                echo " "
+                echo -e "\e[1;34mSi ya has ejecutado esta opcion anteriormente y algo ha salido mal desmonta la consola y vuelve a ejecutar esta\e[0m"
+                echo -e "\e[1;34mopcion y, al llegar a este punto, desconecta la bateria y vuelve a conectarla antes de realizar lo siguiente.\e[0m"
+                echo " "
+                echo " "
+                echo -e "\e[1;31mPulsa y manten pulsado el boton de encendido y justo despues pulsa cualquier tecla para continuar...\e[0m"
+                read -n 1 -s -r -p ""
+                clear
+                cd /home/$usuario/gameandwatch/game-and-watch-patch
+                make clean
+                #make PATCH_PARAMS="--internal-only" flash_patched_int
+                #make PATCH_PARAMS="--device=$consola --internal-only" flash_patched
+                make PATCH_PARAMS="--device=$consola" LARGE_FLASH=1 flash_patched
+                cd -
+                echo " "
+                echo " "
+                echo "Proceso 2/2 concluido."
+                read -n 1 -s -r -p "Presiona cualquier tecla para continuar"
+            else
+                echo "No se ha encontrado internal_flash_backup_$consola.bin, cancelando..."
+                sleep 2
+            fi
+        else
+            echo "No se ha encontrado flash_backup_$consola.bin, cancelando..."
+            sleep 2
+        fi
+        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+        --title "Instalar firmware original + Retro-Go  en consola con 64MB" \
+        --msgbox "Proceso realizado." 0 0
+    else
+            dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+            --title "Instalar firmware original + Retro-Go  en consola con 64MB" \
+            --msgbox "Proceso cancelado." 0 0
+    fi
+    ./scene/2.2.4-cfw-retro-go-64mb-$consola.sh
+    clear;;
+  2)clear
+    dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+    --title "Compilar Retro-Go" \
+    --yesno "Se procedera a compilar RetroGo y se incluiran las roms que existan en /home/$usuario/game-and-watch-retro-go/roms/. ¿Deseas continuar?" 0 0
+    ans=$?
+    if [ $ans -eq 0 ]; then
+        clear
+        cd /home/$usuario/gameandwatch/game-and-watch-retro-go
+        make clean
+        make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=63 EXTFLASH_OFFSET=1048576 INTFLASH_BANK=2 GNW_TARGET=$consola COVERFLOW=$caratula
+        cd -
+        echo " "
+        echo " "
+        read -n 1 -s -r -p "Proceso concluido. Presiona cualquier tecla para continuar."
+        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+        --title "Compilar Retro-Go" \
+        --msgbox "Proceso realizado." 0 0
+    else
+        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+        --title "Compilar Retro-Go" \
+        --msgbox "Proceso cancelado." 0 0
+    fi
+    ./scene/2.2.4-cfw-retro-go-64mb-$consola.sh
+    clear;;
+  3)clear
+    dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+    --title "Flashear Retro-Go" \
+    --yesno "Se recomienda realizar el proceso con la batería cargada al 100% para evitar problemas. Se flasheara  el emulador Retro-Go con las roms que existan en /home/$usuario/game-and-watch-retro-go/roms/" 0 0
+    ans=$?
+    if [ $ans -eq 0 ]; then
+        clear
+        echo " "
+        echo -e "\e[1;34mSi ya has ejecutado esta opcion anteriormente y algo ha salido mal desmonta la consola y vuelve a ejecutar esta\e[0m"
+        echo -e "\e[1;34mopcion y, al llegar a este punto, desconecta la bateria y vuelve a conectarla antes de realizar lo siguiente.\e[0m"
+        echo " "
+        echo " "
+        echo -e "\e[0;32mSi durante el siguiente proceso nos dice que ha fallado el flasheo, que no puede conectar y nos pregunta si\e[0m"
+        echo -e "\e[0;32mvamos a hacer un power cycle (quitar bateria, reconectar y encender) pulsaremos el boton de encendido y lo \e[0m"
+        echo -e "\e[0;32mmantendremos pulsado unos segundos, le diremos que si con \"y\" (yes), entonces el proceso continuara.\e[0m"
+        echo -e "\e[1;31mPulsa y manten pulsado el boton de encendido y justo despues pulsa cualquier tecla para continuar...\nATENCION: No sueltes el boton al menos hasta que empiece a borrar la memoria externa (cuando pone \"Erasing xxxx bytes...\" en la pantalla)\e[0m"
+        read -n 1 -s -r -p ""
+        cd /home/$usuario/gameandwatch/game-and-watch-retro-go
+        make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=63 EXTFLASH_OFFSET=1048576 INTFLASH_BANK=2 GNW_TARGET=$consola COVERFLOW=$caratula flash
+        cd -
+        echo " "
+        echo " "
+        read -n 1 -s -r -p "Proceso concluido. Presiona cualquier tecla para continuar."
+        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+        --title "Instalar solo Retro-Go" \
+        --msgbox "Proceso realizado." 0 0
+    else
+        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+        --title "Instalar solo Retro-Go" \
+        --msgbox "Proceso cancelado." 0 0
+    fi
+    ./scene/2.2.4-cfw-retro-go-64mb-$consola.sh
+    clear;;
+esac
+clear

--- a/scene/2.2.4-save-state-mario.sh
+++ b/scene/2.2.4-save-state-mario.sh
@@ -4,7 +4,7 @@
 INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="mario"
-proc="6"
+proc="4"
 caratula="0"
 
 clear

--- a/scene/2.2.4-save-state-mario.sh
+++ b/scene/2.2.4-save-state-mario.sh
@@ -12,9 +12,10 @@ dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO
 --ok-label Apply \
 --cancel-label Exit \
 --menu "Selecciona con las flechas la opcion deseada:" 12 140 15 \
-   1 "CFW con los parametros para 64MB" \
+   1 "prueba" \
    2 "Compilar Retro-Go con los parametros para 64MB" \
-   3 "Flashear Retro-Go con los parametros para 64MB" 2>"${INPUT}"
+   3 "Flashear Retro-Go con los parametros para 64MB" \
+   4 "Descarga y restauracion de saves-states con parametros 64MB"   2>"${INPUT}"
 menuitem=$(<"${INPUT}")
 case $menuitem in
   1)clear
@@ -130,5 +131,8 @@ case $menuitem in
     fi
     ./scene/2.2.4-cfw-retro-go-64mb-$consola.sh
     clear;;
+  4)clear
+    ./scene/2.2.4-save-state-$consola.sh
+	clear
 esac
 clear

--- a/scene/2.2.4-save-state-mario.sh
+++ b/scene/2.2.4-save-state-mario.sh
@@ -4,7 +4,7 @@
 INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="mario"
-proc="4"
+proc="6"
 caratula="0"
 
 clear
@@ -27,7 +27,13 @@ dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO
        --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
        --ok-label Apply \
        --cancel-label Exit \
-       --menu "Selecciona con las flechas la opcion deseada:" 12 140 15 \
+       --menu "
+Usuario actual: $usuario
+Consola seleccionada: $consola
+Opcion caratulas: $caratula (0=NO y 1=SI)
+Save states: /home/$usuario/game-and-watch-retro-go/save_states/
+
+Selecciona con las flechas la opcion deseada:" 0 0 0 \
           1 "Hacer backup de los save states existentes que hay en la G&W con chip de 64MB" \
           2 "Restaurar los save states desde el pc a la G&W con chip de 64MB" \
           3 "Borrar los saves states existentes en la G&W con chip de 64MB para dejarla limpia"   2>"${INPUT}"

--- a/scene/2.2.4-save-state-mario.sh
+++ b/scene/2.2.4-save-state-mario.sh
@@ -28,9 +28,9 @@ dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO
        --ok-label Apply \
        --cancel-label Exit \
        --menu "Selecciona con las flechas la opcion deseada:" 12 140 15 \
-          1 "Hacer backup de los save states existentes en la G&W" \
-          2 "Restaurar los save states desde el pc a la G&W " \
-          3 "Borrar los saves states existentes en la G&W para dejarla limpia"   2>"${INPUT}"
+          1 "Hacer backup de los save states existentes que hay en la G&W con chip de 64MB" \
+          2 "Restaurar los save states desde el pc a la G&W con chip de 64MB" \
+          3 "Borrar los saves states existentes en la G&W con chip de 64MB para dejarla limpia"   2>"${INPUT}"
 menuitem=$(<"${INPUT}")
 case $menuitem in
   1)clear

--- a/scene/2.2.4-save-state-mario.sh
+++ b/scene/2.2.4-save-state-mario.sh
@@ -5,134 +5,56 @@ INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="mario"
 proc="4"
-caratula="0"
+caratula="1"
 
-dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.4-cfw-retro-go-64mb-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
---title "G&W CFW + Retro-Go 64MB /// INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Roms en /home/$usuario/game-and-watch-retro-go/roms/" \
+clear
+dpkg -s libncurses5 > libncurses5.txt
+if grep "install ok installed" ./libncurses5.txt ; then
+        echo "Encontrado paquete libncurses5, se prosigue..."
+        sleep 0.5
+else
+        echo "No encontrado paquete dialog necesario, instalando..."
+        echo " "
+        sudo apt install -y libncurses5
+        echo " "
+        echo "Instalado!!"
+        sleep 0.5
+fi
+
+dialog --msgbox "G&W Utilidad para backup, resturacion y borrado de save states. Una vez descargados los save states estan ubicados en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" 0 0
+dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.4-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+--title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
 --ok-label Apply \
 --cancel-label Exit \
 --menu "Selecciona con las flechas la opcion deseada:" 12 140 15 \
-   1 "prueba" \
-   2 "Compilar Retro-Go con los parametros para 64MB" \
-   3 "Flashear Retro-Go con los parametros para 64MB" \
-   4 "Descarga y restauracion de saves-states con parametros 64MB"   2>"${INPUT}"
+   1 "Hacer backup de los save states existentes en la G&W" \
+   2 "Restaurar los save states desde el pc a la G&W " \
+   3 "Borrar los saves states existentes en la G&W para dejarla limpia"   2>"${INPUT}"
 menuitem=$(<"${INPUT}")
 case $menuitem in
   1)clear
-    dialog --backtitle "G&W $consola - Utilidades de flasheo" \
-    --title "Instalar Retro-Go en consola G&W $consola con 64MB" \
-    --yesno "Se recomienda realizar el proceso con la batería cargada al 100% para evitar problemas. Este proceso es solamente para una consola con el chip de 64MB instalado.\n\n¡¡¡ATENCION!!!\nSI SE TIENE DIFERENTE CANTIDAD DE MEMORIA CANCELAR EL PROCESO y una vez vuelto al menu seleccionar el correcto.\n\nSe flasheara un custom firmware que consta del menu original de la consola ademas del acceso al emulador Retro-Go. El emulador aparecera al realizar el combo de botones \"LEFT\" + \"GAME\". ¿Deseas continuar?" 0 0
-    ans=$?
-    if [ $ans -eq 0 ]; then
-        clear
-        if [ -f /home/$usuario/gameandwatch/game-and-watch-backup/backups/flash_backup_$consola.bin ]; then
-            echo "flash_backup_$consola.bin encontrado"
-            sleep 0.5
-            if [ -f /home/$usuario/gameandwatch/game-and-watch-backup/backups/internal_flash_backup_$consola.bin ]; then
-                echo "internal_flash_backup_$consola.bin encontrado"
-                sleep 0.5
-                cp /home/$usuario/gameandwatch/game-and-watch-backup/backups/flash_backup_$consola.bin /home/$usuario/gameandwatch/game-and-watch-patch
-                cp /home/$usuario/gameandwatch/game-and-watch-backup/backups/internal_flash_backup_$consola.bin /home/$usuario/gameandwatch/game-and-watch-patch
-                echo " "
-                echo "Se han copiado los archivos de la flash interna y externa"
-                echo " "
-                echo " "
-                echo "Proceso 1/2 concluido."
-                echo " "
-                echo -e "\e[1;34mSi ya has ejecutado esta opcion anteriormente y algo ha salido mal desmonta la consola y vuelve a ejecutar esta\e[0m"
-                echo -e "\e[1;34mopcion y, al llegar a este punto, desconecta la bateria y vuelve a conectarla antes de realizar lo siguiente.\e[0m"
-                echo " "
-                echo " "
-                echo -e "\e[1;31mPulsa y manten pulsado el boton de encendido y justo despues pulsa cualquier tecla para continuar...\e[0m"
-                read -n 1 -s -r -p ""
-                clear
-                cd /home/$usuario/gameandwatch/game-and-watch-patch
-                make clean
-                #make PATCH_PARAMS="--internal-only" flash_patched_int
-                #make PATCH_PARAMS="--device=$consola --internal-only" flash_patched
-                make PATCH_PARAMS="--device=$consola" LARGE_FLASH=1 flash_patched
-                cd -
-                echo " "
-                echo " "
-                echo "Proceso 2/2 concluido."
-                read -n 1 -s -r -p "Presiona cualquier tecla para continuar"
-            else
-                echo "No se ha encontrado internal_flash_backup_$consola.bin, cancelando..."
-                sleep 2
-            fi
-        else
-            echo "No se ha encontrado flash_backup_$consola.bin, cancelando..."
-            sleep 2
-        fi
-        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
-        --title "Instalar firmware original + Retro-Go  en consola con 64MB" \
-        --msgbox "Proceso realizado." 0 0
-    else
-            dialog --backtitle "G&W $consola - Utilidades de flasheo" \
-            --title "Instalar firmware original + Retro-Go  en consola con 64MB" \
-            --msgbox "Proceso cancelado." 0 0
-    fi
-    ./scene/2.2.4-cfw-retro-go-64mb-$consola.sh
+    cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
+	make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=63 EXTFLASH_OFFSET=1048576 INTFLASH_BANK=2 GNW_TARGET=$consola COVERFLOW=$caratula flash_saves_backup
+	cd -
+	sleep 5
+    dialog --msgbox "Save states descargados en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" 0 0
+    ./scene/2.2.4-save-state-$consola.sh
     clear;;
   2)clear
-    dialog --backtitle "G&W $consola - Utilidades de flasheo" \
-    --title "Compilar Retro-Go" \
-    --yesno "Se procedera a compilar RetroGo y se incluiran las roms que existan en /home/$usuario/game-and-watch-retro-go/roms/. ¿Deseas continuar?" 0 0
-    ans=$?
-    if [ $ans -eq 0 ]; then
-        clear
-        cd /home/$usuario/gameandwatch/game-and-watch-retro-go
-        make clean
-        make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=63 EXTFLASH_OFFSET=1048576 INTFLASH_BANK=2 GNW_TARGET=$consola COVERFLOW=$caratula
-        cd -
-        echo " "
-        echo " "
-        read -n 1 -s -r -p "Proceso concluido. Presiona cualquier tecla para continuar."
-        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
-        --title "Compilar Retro-Go" \
-        --msgbox "Proceso realizado." 0 0
-    else
-        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
-        --title "Compilar Retro-Go" \
-        --msgbox "Proceso cancelado." 0 0
-    fi
-    ./scene/2.2.4-cfw-retro-go-64mb-$consola.sh
+    cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
+	make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=63 EXTFLASH_OFFSET=1048576 INTFLASH_BANK=2 GNW_TARGET=$consola COVERFLOW=$caratula flash_saves_restore
+	cd -
+    sleep 5
+	dialog --msgbox "Proceso concluido..." 0 0; sleep 2
+    ./scene/2.2.4-save-state-$consola.sh
     clear;;
   3)clear
-    dialog --backtitle "G&W $consola - Utilidades de flasheo" \
-    --title "Flashear Retro-Go" \
-    --yesno "Se recomienda realizar el proceso con la batería cargada al 100% para evitar problemas. Se flasheara  el emulador Retro-Go con las roms que existan en /home/$usuario/game-and-watch-retro-go/roms/" 0 0
-    ans=$?
-    if [ $ans -eq 0 ]; then
-        clear
-        echo " "
-        echo -e "\e[1;34mSi ya has ejecutado esta opcion anteriormente y algo ha salido mal desmonta la consola y vuelve a ejecutar esta\e[0m"
-        echo -e "\e[1;34mopcion y, al llegar a este punto, desconecta la bateria y vuelve a conectarla antes de realizar lo siguiente.\e[0m"
-        echo " "
-        echo " "
-        echo -e "\e[0;32mSi durante el siguiente proceso nos dice que ha fallado el flasheo, que no puede conectar y nos pregunta si\e[0m"
-        echo -e "\e[0;32mvamos a hacer un power cycle (quitar bateria, reconectar y encender) pulsaremos el boton de encendido y lo \e[0m"
-        echo -e "\e[0;32mmantendremos pulsado unos segundos, le diremos que si con \"y\" (yes), entonces el proceso continuara.\e[0m"
-        echo -e "\e[1;31mPulsa y manten pulsado el boton de encendido y justo despues pulsa cualquier tecla para continuar...\nATENCION: No sueltes el boton al menos hasta que empiece a borrar la memoria externa (cuando pone \"Erasing xxxx bytes...\" en la pantalla)\e[0m"
-        read -n 1 -s -r -p ""
-        cd /home/$usuario/gameandwatch/game-and-watch-retro-go
-        make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=63 EXTFLASH_OFFSET=1048576 INTFLASH_BANK=2 GNW_TARGET=$consola COVERFLOW=$caratula flash
-        cd -
-        echo " "
-        echo " "
-        read -n 1 -s -r -p "Proceso concluido. Presiona cualquier tecla para continuar."
-        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
-        --title "Instalar solo Retro-Go" \
-        --msgbox "Proceso realizado." 0 0
-    else
-        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
-        --title "Instalar solo Retro-Go" \
-        --msgbox "Proceso cancelado." 0 0
-    fi
-    ./scene/2.2.4-cfw-retro-go-64mb-$consola.sh
-    clear;;
-  4)clear
+    cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
+	make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=63 EXTFLASH_OFFSET=1048576 INTFLASH_BANK=2 GNW_TARGET=$consola COVERFLOW=$caratula flash_saves_erase
+	cd -
+    sleep 5
+	dialog --msgbox "Proceso concluido..." 0 0; sleep 2
     ./scene/2.2.4-save-state-$consola.sh
-	clear
+    clear;;
 esac
 clear

--- a/scene/2.2.4-save-state-mario.sh
+++ b/scene/2.2.4-save-state-mario.sh
@@ -5,7 +5,7 @@ INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="mario"
 proc="4"
-caratula="1"
+caratula="0"
 
 clear
 dpkg -s libncurses5 > libncurses5.txt
@@ -47,7 +47,8 @@ case $menuitem in
         cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
         make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=63 EXTFLASH_OFFSET=1048576 INTFLASH_BANK=2 GNW_TARGET=$consola COVERFLOW=$caratula flash_saves_backup
         cd -
-        #sleep 5
+        echo -e "\e[1;31mPulsa cualquier tecla para continuar...\e[0m"
+        read -n 1 -s -r -p ""
         dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.4-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
                --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
                --msgbox "Proceso realizado. Save states descargados en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" 0 0
@@ -72,7 +73,8 @@ case $menuitem in
         cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
         make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=63 EXTFLASH_OFFSET=1048576 INTFLASH_BANK=2 GNW_TARGET=$consola COVERFLOW=$caratula flash_saves_restore
         cd -
-        #sleep 5
+        echo -e "\e[1;31mPulsa cualquier tecla para continuar...\e[0m"
+        read -n 1 -s -r -p ""
         dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.4-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
                --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
                --msgbox "Proceso realizado." 0 0
@@ -97,7 +99,8 @@ case $menuitem in
         cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
         make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=63 EXTFLASH_OFFSET=1048576 INTFLASH_BANK=2 GNW_TARGET=$consola COVERFLOW=$caratula flash_saves_erase
         cd -
-        #sleep 5
+        echo -e "\e[1;31mPulsa cualquier tecla para continuar...\e[0m"
+        read -n 1 -s -r -p ""
         dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.4-save-state-mario.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
                --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
                --msgbox "Proceso realizado." 0 0

--- a/scene/2.2.4-save-state-zelda.sh
+++ b/scene/2.2.4-save-state-zelda.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+#By julenvitoria
+
+INPUT=/tmp/$MENU.sh.$$
+usuario="kde"
+consola="zelda"
+proc="4"
+caratula="0"
+
+dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.4-cfw-retro-go-64mb-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+--title "G&W CFW + Retro-Go 64MB /// INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Roms en /home/$usuario/game-and-watch-retro-go/roms/" \
+--ok-label Apply \
+--cancel-label Exit \
+--menu "Selecciona con las flechas la opcion deseada:" 12 140 15 \
+   1 "CFW con los parametros para 64MB" \
+   2 "Compilar Retro-Go con los parametros para 64MB" \
+   3 "Flashear Retro-Go con los parametros para 64MB" 2>"${INPUT}"
+menuitem=$(<"${INPUT}")
+case $menuitem in
+  1)clear
+    dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+    --title "Instalar Retro-Go en consola G&W $consola con 64MB" \
+    --yesno "Se recomienda realizar el proceso con la batería cargada al 100% para evitar problemas. Este proceso es solamente para una consola con el chip de 64MB.\n\n¡¡¡ATENCION!!!\nSI SE TIENE DIFERENTE CANTIDAD DE MEMORIA CANCELAR EL PROCESO y una vez vuelto al menu seleccionar el correcto.\n\nSe flasheara un custom firmware que consta del menu original de la consola ademas del acceso al emulador Retro-Go. El emulador aparecera al realizar el combo de botones \"LEFT\" + \"GAME\". ¿Deseas continuar?" 0 0
+    ans=$?
+    if [ $ans -eq 0 ]; then
+        clear
+        if [ -f /home/$usuario/gameandwatch/game-and-watch-backup/backups/flash_backup_$consola.bin ]; then
+            echo "flash_backup_$consola.bin encontrado"
+            sleep 0.5
+            if [ -f /home/$usuario/gameandwatch/game-and-watch-backup/backups/internal_flash_backup_$consola.bin ]; then
+                echo "internal_flash_backup_$consola.bin encontrado"
+                sleep 0.5
+                cp /home/$usuario/gameandwatch/game-and-watch-backup/backups/flash_backup_$consola.bin /home/$usuario/gameandwatch/game-and-watch-patch
+                cp /home/$usuario/gameandwatch/game-and-watch-backup/backups/internal_flash_backup_$consola.bin /home/$usuario/gameandwatch/game-and-watch-patch
+                echo " "
+                echo "Se han copiado los archivos de la flash interna y externa"
+                echo " "
+                echo " "
+                echo "Proceso 1/2 concluido."
+                echo " "
+                echo -e "\e[1;34mSi ya has ejecutado esta opcion anteriormente y algo ha salido mal desmonta la consola y vuelve a ejecutar esta\e[0m"
+                echo -e "\e[1;34mopcion y, al llegar a este punto, desconecta la bateria y vuelve a conectarla antes de realizar lo siguiente.\e[0m"
+                echo " "
+                echo " "
+                echo -e "\e[1;31mPulsa y manten pulsado el boton de encendido y justo despues pulsa cualquier tecla para continuar...\e[0m"
+                read -n 1 -s -r -p ""
+                clear
+                cd /home/$usuario/gameandwatch/game-and-watch-patch
+                make clean
+                make PATCH_PARAMS="--device=$consola" LARGE_FLASH=1 flash_patched
+                cd -
+                echo " "
+                echo " "
+                echo "Proceso 2/2 concluido."
+                read -n 1 -s -r -p "Presiona cualquier tecla para continuar"
+            else
+                echo "No se ha encontrado internal_flash_backup_$consola.bin, cancelando..."
+                sleep 2
+            fi
+        else
+            echo "No se ha encontrado flash_backup_$consola.bin, cancelando..."
+            sleep 2
+        fi
+        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+        --title "Instalar firmware original + Retro-Go  en consola con 64MB" \
+        --msgbox "Proceso realizado." 0 0
+    else
+            dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+            --title "Instalar firmware original + Retro-Go  en consola con 64MB" \
+            --msgbox "Proceso cancelado." 0 0
+    fi
+    ./scene/2.2.4-cfw-retro-go-64mb-$consola.sh
+    clear;;
+  2)clear
+    dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+    --title "Compilar Retro-Go" \
+    --yesno "Se procedera a compilar RetroGo y se incluiran las roms que existan en /home/$usuario/game-and-watch-retro-go/roms/. ¿Deseas continuar?" 0 0
+    ans=$?
+    if [ $ans -eq 0 ]; then
+        clear
+        cd /home/$usuario/gameandwatch/game-and-watch-retro-go
+        make clean
+        make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=60 EXTFLASH_OFFSET=4194304 INTFLASH_BANK=2 GNW_TARGET=$consola COVERFLOW=$caratula
+        cd -
+        echo " "
+        echo " "
+        read -n 1 -s -r -p "Proceso concluido. Presiona cualquier tecla para continuar."
+        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+        --title "Compilar Retro-Go" \
+        --msgbox "Proceso realizado." 0 0
+    else
+        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+        --title "Compilar Retro-Go" \
+        --msgbox "Proceso cancelado." 0 0
+    fi
+    ./scene/2.2.4-cfw-retro-go-64mb-$consola.sh
+    clear;;
+  3)clear
+    dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+    --title "Flashear Retro-Go" \
+    --yesno "Se recomienda realizar el proceso con la batería cargada al 100% para evitar problemas. Se flasheara  el emulador Retro-Go con las roms que existan en /home/$usuario/game-and-watch-retro-go/roms/" 0 0
+    ans=$?
+    if [ $ans -eq 0 ]; then
+        clear
+        echo " "
+        echo -e "\e[1;34mSi ya has ejecutado esta opcion anteriormente y algo ha salido mal desmonta la consola y vuelve a ejecutar esta\e[0m"
+        echo -e "\e[1;34mopcion y, al llegar a este punto, desconecta la bateria y vuelve a conectarla antes de realizar lo siguiente.\e[0m"
+        echo " "
+        echo " "
+        echo -e "\e[0;32mSi durante el siguiente proceso nos dice que ha fallado el flasheo, que no puede conectar y nos pregunta si\e[0m"
+        echo -e "\e[0;32mvamos a hacer un power cycle (quitar bateria, reconectar y encender) pulsaremos el boton de encendido y lo \e[0m"
+        echo -e "\e[0;32mmantendremos pulsado unos segundos, le diremos que si con \"y\" (yes), entonces el proceso continuara.\e[0m"
+        echo -e "\e[1;31mPulsa y manten pulsado el boton de encendido y justo despues pulsa cualquier tecla para continuar...\nATENCION: No sueltes el boton al menos hasta que empiece a borrar la memoria externa (cuando pone \"Erasing xxxx bytes...\" en la pantalla)\e[0m"
+        read -n 1 -s -r -p ""
+        cd /home/$usuario/gameandwatch/game-and-watch-retro-go
+        make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=60 EXTFLASH_OFFSET=4194304 INTFLASH_BANK=2 GNW_TARGET=$consola COVERFLOW=$caratula flash
+        cd -
+        echo " "
+        echo " "
+        read -n 1 -s -r -p "Proceso concluido. Presiona cualquier tecla para continuar."
+        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+        --title "Instalar solo Retro-Go" \
+        --msgbox "Proceso realizado." 0 0
+    else
+        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
+        --title "Instalar solo Retro-Go" \
+        --msgbox "Proceso cancelado." 0 0
+    fi
+    ./scene/2.2.4-cfw-retro-go-64mb-$consola.sh
+    clear;;
+esac
+clear

--- a/scene/2.2.4-save-state-zelda.sh
+++ b/scene/2.2.4-save-state-zelda.sh
@@ -4,7 +4,7 @@
 INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="zelda"
-proc="6"
+proc="4"
 caratula="0"
 
 clear

--- a/scene/2.2.4-save-state-zelda.sh
+++ b/scene/2.2.4-save-state-zelda.sh
@@ -12,9 +12,10 @@ dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO
 --ok-label Apply \
 --cancel-label Exit \
 --menu "Selecciona con las flechas la opcion deseada:" 12 140 15 \
-   1 "CFW con los parametros para 64MB" \
+   1 "prueba" \
    2 "Compilar Retro-Go con los parametros para 64MB" \
-   3 "Flashear Retro-Go con los parametros para 64MB" 2>"${INPUT}"
+   3 "Flashear Retro-Go con los parametros para 64MB" \
+   4 "Descarga y restauracion de saves-states con parametros 64MB"   2>"${INPUT}"
 menuitem=$(<"${INPUT}")
 case $menuitem in
   1)clear
@@ -128,5 +129,8 @@ case $menuitem in
     fi
     ./scene/2.2.4-cfw-retro-go-64mb-$consola.sh
     clear;;
+  4)clear
+    ./scene/2.2.4-save-state-$consola.sh
+	clear
 esac
 clear

--- a/scene/2.2.4-save-state-zelda.sh
+++ b/scene/2.2.4-save-state-zelda.sh
@@ -4,7 +4,7 @@
 INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="zelda"
-proc="4"
+proc="6"
 caratula="0"
 
 clear
@@ -27,7 +27,13 @@ dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO
        --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
        --ok-label Apply \
        --cancel-label Exit \
-       --menu "Selecciona con las flechas la opcion deseada:" 12 140 15 \
+       --menu "
+Usuario actual: $usuario
+Consola seleccionada: $consola
+Opcion caratulas: $caratula (0=NO y 1=SI)
+Save states: /home/$usuario/game-and-watch-retro-go/save_states/
+
+Selecciona con las flechas la opcion deseada:" 0 0 0 \
           1 "Hacer backup de los save states existentes que hay en la G&W con chip de 64MB" \
           2 "Restaurar los save states desde el pc a la G&W con chip de 64MB" \
           3 "Borrar los saves states existentes en la G&W con chip de 64MB para dejarla limpia"   2>"${INPUT}"

--- a/scene/2.2.4-save-state-zelda.sh
+++ b/scene/2.2.4-save-state-zelda.sh
@@ -7,130 +7,106 @@ consola="zelda"
 proc="4"
 caratula="1"
 
+clear
+dpkg -s libncurses5 > libncurses5.txt
+if grep "install ok installed" ./libncurses5.txt ; then
+        echo "Encontrado paquete libncurses5, se prosigue..."
+        sleep 0.5
+else
+        echo "No encontrado paquete dialog necesario, instalando..."
+        echo " "
+        sudo apt install -y libncurses5
+        echo " "
+        echo "Instalado!!"
+        sleep 0.5
+fi
+
 dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.4-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
---title "G&W Utilidad para backup, resturacion y borrado de save states /// INFO: Usuario=$usuario --- Consola seleccionada=$consola " \
---ok-label Apply \
---cancel-label Exit \
---menu "Selecciona con las flechas la opcion deseada:" 12 140 15 \
-   1 "prueba" \
-   2 "Compilar Retro-Go con los parametros para 64MB" \
-   3 "Flashear Retro-Go con los parametros para 64MB" \
-   4 "Descarga y restauracion de saves-states con parametros 64MB"   2>"${INPUT}"
+       --msgbox "G&W Utilidad para backup, resturacion y borrado de save states. Una vez descargados los save states estan ubicados en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" 0 0
+dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.4-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+       --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+       --ok-label Apply \
+       --cancel-label Exit \
+       --menu "Selecciona con las flechas la opcion deseada:" 12 140 15 \
+          1 "Hacer backup de los save states existentes que hay en la G&W con chip de 64MB" \
+          2 "Restaurar los save states desde el pc a la G&W con chip de 64MB" \
+          3 "Borrar los saves states existentes en la G&W con chip de 64MB para dejarla limpia"   2>"${INPUT}"
 menuitem=$(<"${INPUT}")
 case $menuitem in
   1)clear
-    dialog --backtitle "G&W $consola - Utilidades de flasheo" \
-    --title "Instalar Retro-Go en consola G&W $consola con 64MB" \
-    --yesno "Se recomienda realizar el proceso con la batería cargada al 100% para evitar problemas. Este proceso es solamente para una consola con el chip de 64MB.\n\n¡¡¡ATENCION!!!\nSI SE TIENE DIFERENTE CANTIDAD DE MEMORIA CANCELAR EL PROCESO y una vez vuelto al menu seleccionar el correcto.\n\nSe flasheara un custom firmware que consta del menu original de la consola ademas del acceso al emulador Retro-Go. El emulador aparecera al realizar el combo de botones \"LEFT\" + \"GAME\". ¿Deseas continuar?" 0 0
+    dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.4-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+           --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+           --yesno "¡¡¡ATENCION!!! El proceso de BACKUP de los save states puede llegar a tardar varios minutos dependiendo de la cantidad de roms que haya en la G&W y pararlo puede ocasionar errores. ¿Deseas continuar?" 0 0
     ans=$?
     if [ $ans -eq 0 ]; then
         clear
-        if [ -f /home/$usuario/gameandwatch/game-and-watch-backup/backups/flash_backup_$consola.bin ]; then
-            echo "flash_backup_$consola.bin encontrado"
-            sleep 0.5
-            if [ -f /home/$usuario/gameandwatch/game-and-watch-backup/backups/internal_flash_backup_$consola.bin ]; then
-                echo "internal_flash_backup_$consola.bin encontrado"
-                sleep 0.5
-                cp /home/$usuario/gameandwatch/game-and-watch-backup/backups/flash_backup_$consola.bin /home/$usuario/gameandwatch/game-and-watch-patch
-                cp /home/$usuario/gameandwatch/game-and-watch-backup/backups/internal_flash_backup_$consola.bin /home/$usuario/gameandwatch/game-and-watch-patch
-                echo " "
-                echo "Se han copiado los archivos de la flash interna y externa"
-                echo " "
-                echo " "
-                echo "Proceso 1/2 concluido."
-                echo " "
-                echo -e "\e[1;34mSi ya has ejecutado esta opcion anteriormente y algo ha salido mal desmonta la consola y vuelve a ejecutar esta\e[0m"
-                echo -e "\e[1;34mopcion y, al llegar a este punto, desconecta la bateria y vuelve a conectarla antes de realizar lo siguiente.\e[0m"
-                echo " "
-                echo " "
-                echo -e "\e[1;31mPulsa y manten pulsado el boton de encendido y justo despues pulsa cualquier tecla para continuar...\e[0m"
-                read -n 1 -s -r -p ""
-                clear
-                cd /home/$usuario/gameandwatch/game-and-watch-patch
-                make clean
-                make PATCH_PARAMS="--device=$consola" LARGE_FLASH=1 flash_patched
-                cd -
-                echo " "
-                echo " "
-                echo "Proceso 2/2 concluido."
-                read -n 1 -s -r -p "Presiona cualquier tecla para continuar"
-            else
-                echo "No se ha encontrado internal_flash_backup_$consola.bin, cancelando..."
-                sleep 2
-            fi
-        else
-            echo "No se ha encontrado flash_backup_$consola.bin, cancelando..."
-            sleep 2
-        fi
-        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
-        --title "Instalar firmware original + Retro-Go  en consola con 64MB" \
-        --msgbox "Proceso realizado." 0 0
+        echo -e "\e[1;31mEnciende la consola y entra al menu Retro-Go con los botones LEFT+GAME y dejala esperando en el listado de las roms.\e[0m"
+        echo ""
+        echo -e "\e[1;31mPara continuar con el proceso pulsa cualquier tecla...\e[0m"
+        read -n 1 -s -r -p ""
+        cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
+        make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=60 EXTFLASH_OFFSET=4194304 INTFLASH_BANK=2 GNW_TARGET=$consola COVERFLOW=$caratula flash_saves_backup
+        cd -
+        #sleep 5
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.4-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso realizado. Save states descargados en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" 0 0
     else
-            dialog --backtitle "G&W $consola - Utilidades de flasheo" \
-            --title "Instalar firmware original + Retro-Go  en consola con 64MB" \
-            --msgbox "Proceso cancelado." 0 0
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.4-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso cancelado." 0 0
     fi
     ./scene/2.2.4-save-state-$consola.sh
     clear;;
   2)clear
-    dialog --backtitle "G&W $consola - Utilidades de flasheo" \
-    --title "Compilar Retro-Go" \
-    --yesno "Se procedera a compilar RetroGo y se incluiran las roms que existan en /home/$usuario/game-and-watch-retro-go/roms/. ¿Deseas continuar?" 0 0
+    dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.4-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+           --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+           --yesno "¡¡¡ATENCION!!! El proceso RESTAURACION de los save states puede llegar a tardar varios minutos dependiendo de la cantidad de roms que haya en la G&W y pararlo puede ocasionar errores. ¿Deseas continuar?" 0 0
     ans=$?
     if [ $ans -eq 0 ]; then
         clear
-        cd /home/$usuario/gameandwatch/game-and-watch-retro-go
-        make clean
-        make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=60 EXTFLASH_OFFSET=4194304 INTFLASH_BANK=2 GNW_TARGET=$consola COVERFLOW=$caratula
+        echo -e "\e[1;31mEnciende la consola y entra al menu Retro-Go con los botones LEFT+GAME y dejala esperando en el listado de las roms.\e[0m"
+        echo ""
+        echo -e "\e[1;31mPara continuar con el proceso pulsa cualquier tecla...\e[0m"
+        read -n 1 -s -r -p ""
+        cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
+        make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=60 EXTFLASH_OFFSET=4194304 INTFLASH_BANK=2 GNW_TARGET=$consola COVERFLOW=$caratula flash_saves_restore
         cd -
-        echo " "
-        echo " "
-        read -n 1 -s -r -p "Proceso concluido. Presiona cualquier tecla para continuar."
-        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
-        --title "Compilar Retro-Go" \
-        --msgbox "Proceso realizado." 0 0
+        #sleep 5
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.4-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso realizado." 0 0
     else
-        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
-        --title "Compilar Retro-Go" \
-        --msgbox "Proceso cancelado." 0 0
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.4-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso cancelado." 0 0
     fi
     ./scene/2.2.4-save-state-$consola.sh
     clear;;
   3)clear
-    dialog --backtitle "G&W $consola - Utilidades de flasheo" \
-    --title "Flashear Retro-Go" \
-    --yesno "Se recomienda realizar el proceso con la batería cargada al 100% para evitar problemas. Se flasheara  el emulador Retro-Go con las roms que existan en /home/$usuario/game-and-watch-retro-go/roms/" 0 0
+    dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.4-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+           --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+           --yesno "¡¡¡ATENCION!!! El proceso BORRAR los save states puede llegar a tardar varios minutos dependiendo de la cantidad de roms que haya en la G&W y pararlo puede ocasionar errores. ¿Deseas continuar?" 0 0
     ans=$?
     if [ $ans -eq 0 ]; then
         clear
-        echo " "
-        echo -e "\e[1;34mSi ya has ejecutado esta opcion anteriormente y algo ha salido mal desmonta la consola y vuelve a ejecutar esta\e[0m"
-        echo -e "\e[1;34mopcion y, al llegar a este punto, desconecta la bateria y vuelve a conectarla antes de realizar lo siguiente.\e[0m"
-        echo " "
-        echo " "
-        echo -e "\e[0;32mSi durante el siguiente proceso nos dice que ha fallado el flasheo, que no puede conectar y nos pregunta si\e[0m"
-        echo -e "\e[0;32mvamos a hacer un power cycle (quitar bateria, reconectar y encender) pulsaremos el boton de encendido y lo \e[0m"
-        echo -e "\e[0;32mmantendremos pulsado unos segundos, le diremos que si con \"y\" (yes), entonces el proceso continuara.\e[0m"
-        echo -e "\e[1;31mPulsa y manten pulsado el boton de encendido y justo despues pulsa cualquier tecla para continuar...\nATENCION: No sueltes el boton al menos hasta que empiece a borrar la memoria externa (cuando pone \"Erasing xxxx bytes...\" en la pantalla)\e[0m"
+        echo -e "\e[1;31mEnciende la consola y entra al menu Retro-Go con los botones LEFT+GAME y dejala esperando en el listado de las roms.\e[0m"
+        echo ""
+        echo -e "\e[1;31mPara continuar con el proceso pulsa cualquier tecla...\e[0m"
         read -n 1 -s -r -p ""
-        cd /home/$usuario/gameandwatch/game-and-watch-retro-go
-        make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=60 EXTFLASH_OFFSET=4194304 INTFLASH_BANK=2 GNW_TARGET=$consola COVERFLOW=$caratula flash
+        cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
+        make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=60 EXTFLASH_OFFSET=4194304 INTFLASH_BANK=2 GNW_TARGET=$consola COVERFLOW=$caratula flash_saves_erase
         cd -
-        echo " "
-        echo " "
-        read -n 1 -s -r -p "Proceso concluido. Presiona cualquier tecla para continuar."
-        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
-        --title "Instalar solo Retro-Go" \
-        --msgbox "Proceso realizado." 0 0
+        #sleep 5
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.4-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso realizado." 0 0
     else
-        dialog --backtitle "G&W $consola - Utilidades de flasheo" \
-        --title "Instalar solo Retro-Go" \
-        --msgbox "Proceso cancelado." 0 0
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.4-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+               --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+               --msgbox "Proceso cancelado." 0 0
     fi
-    ./scene/2.2.4-cfw-retro-go-64mb-$consola.sh
-    clear;;
-  4)clear
     ./scene/2.2.4-save-state-$consola.sh
-	clear
+    clear;;
 esac
 clear

--- a/scene/2.2.4-save-state-zelda.sh
+++ b/scene/2.2.4-save-state-zelda.sh
@@ -5,7 +5,7 @@ INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="zelda"
 proc="4"
-caratula="1"
+caratula="0"
 
 clear
 dpkg -s libncurses5 > libncurses5.txt
@@ -47,7 +47,8 @@ case $menuitem in
         cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
         make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=60 EXTFLASH_OFFSET=4194304 INTFLASH_BANK=2 GNW_TARGET=$consola COVERFLOW=$caratula flash_saves_backup
         cd -
-        #sleep 5
+        echo -e "\e[1;31mPulsa cualquier tecla para continuar...\e[0m"
+        read -n 1 -s -r -p ""
         dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.4-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
                --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
                --msgbox "Proceso realizado. Save states descargados en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" 0 0
@@ -72,7 +73,8 @@ case $menuitem in
         cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
         make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=60 EXTFLASH_OFFSET=4194304 INTFLASH_BANK=2 GNW_TARGET=$consola COVERFLOW=$caratula flash_saves_restore
         cd -
-        #sleep 5
+        echo -e "\e[1;31mPulsa cualquier tecla para continuar...\e[0m"
+        read -n 1 -s -r -p ""
         dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.4-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
                --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
                --msgbox "Proceso realizado." 0 0
@@ -97,7 +99,8 @@ case $menuitem in
         cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
         make -j$proc COMPRESS=lzma EXTFLASH_SIZE_MB=60 EXTFLASH_OFFSET=4194304 INTFLASH_BANK=2 GNW_TARGET=$consola COVERFLOW=$caratula flash_saves_erase
         cd -
-        #sleep 5
+        echo -e "\e[1;31mPulsa cualquier tecla para continuar...\e[0m"
+        read -n 1 -s -r -p ""
         dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.4-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
                --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
                --msgbox "Proceso realizado." 0 0

--- a/scene/2.2.4-save-state-zelda.sh
+++ b/scene/2.2.4-save-state-zelda.sh
@@ -5,10 +5,10 @@ INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="zelda"
 proc="4"
-caratula="0"
+caratula="1"
 
-dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.4-cfw-retro-go-64mb-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
---title "G&W CFW + Retro-Go 64MB /// INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Roms en /home/$usuario/game-and-watch-retro-go/roms/" \
+dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.4-save-state-zelda.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+--title "G&W Utilidad para backup, resturacion y borrado de save states /// INFO: Usuario=$usuario --- Consola seleccionada=$consola " \
 --ok-label Apply \
 --cancel-label Exit \
 --menu "Selecciona con las flechas la opcion deseada:" 12 140 15 \
@@ -70,7 +70,7 @@ case $menuitem in
             --title "Instalar firmware original + Retro-Go  en consola con 64MB" \
             --msgbox "Proceso cancelado." 0 0
     fi
-    ./scene/2.2.4-cfw-retro-go-64mb-$consola.sh
+    ./scene/2.2.4-save-state-$consola.sh
     clear;;
   2)clear
     dialog --backtitle "G&W $consola - Utilidades de flasheo" \
@@ -94,7 +94,7 @@ case $menuitem in
         --title "Compilar Retro-Go" \
         --msgbox "Proceso cancelado." 0 0
     fi
-    ./scene/2.2.4-cfw-retro-go-64mb-$consola.sh
+    ./scene/2.2.4-save-state-$consola.sh
     clear;;
   3)clear
     dialog --backtitle "G&W $consola - Utilidades de flasheo" \

--- a/scene/2.2.C-opcion-caratula.sh
+++ b/scene/2.2.C-opcion-caratula.sh
@@ -24,32 +24,50 @@ case $menuitem in
     sed -i 's/^caratula=.*$/'caratula=\""1"\"'/g' ./scene/2.2-retro-go-zelda.sh
     sed -i 's/^caratula=.*$/'caratula=\""1"\"'/g' ./scene/2.2.1-solo-retro-go-mario.sh
     sed -i 's/^caratula=.*$/'caratula=\""1"\"'/g' ./scene/2.2.1-solo-retro-go-zelda.sh
+	sed -i 's/^caratula=.*$/'caratula=\""1"\"'/g' ./scene/2.2.1-save-state-mario.sh
+    sed -i 's/^caratula=.*$/'caratula=\""1"\"'/g' ./scene/2.2.1-save-state-zelda.sh
     sed -i 's/^caratula=.*$/'caratula=\""1"\"'/g' ./scene/2.2.2-cfw-retro-go-1mb-mario.sh
     sed -i 's/^caratula=.*$/'caratula=\""1"\"'/g' ./scene/2.2.2-cfw-retro-go-4mb-zelda.sh
+	sed -i 's/^caratula=.*$/'caratula=\""1"\"'/g' ./scene/2.2.2-save-state-mario.sh
+    sed -i 's/^caratula=.*$/'caratula=\""1"\"'/g' ./scene/2.2.2-save-state-zelda.sh
     sed -i 's/^caratula=.*$/'caratula=\""1"\"'/g' ./scene/2.2.3-cfw-retro-go-16mb-mario.sh
     sed -i 's/^caratula=.*$/'caratula=\""1"\"'/g' ./scene/2.2.3-cfw-retro-go-16mb-zelda.sh
+	sed -i 's/^caratula=.*$/'caratula=\""1"\"'/g' ./scene/2.2.3-save-state-mario.sh
+    sed -i 's/^caratula=.*$/'caratula=\""1"\"'/g' ./scene/2.2.3-save-state-zelda.sh
     sed -i 's/^caratula=.*$/'caratula=\""1"\"'/g' ./scene/2.2.4-cfw-retro-go-64mb-mario.sh
     sed -i 's/^caratula=.*$/'caratula=\""1"\"'/g' ./scene/2.2.4-cfw-retro-go-64mb-zelda.sh
+	sed -i 's/^caratula=.*$/'caratula=\""1"\"'/g' ./scene/2.2.4-save-state-mario.sh
+    sed -i 's/^caratula=.*$/'caratula=\""1"\"'/g' ./scene/2.2.4-save-state-zelda.sh
     sed -i 's/^caratula=.*$/'caratula=\""1"\"'/g' ./scene/2.2.C-opcion-caratula.sh
     dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.C-opcion-caratula.sh Usuario = $usuario ------------------" \
     --title "G&W $consola menu caratulas" \
     --msgbox "Opcion caratulas ACTIVADA. NOTA:Para flashear caratulas de roms en el menú hará falta colocar en el mismo directorio de la rom un archivo jpg, bmp o png con el mismo nombre de la rom y el propio programa se encargara de comprimirla y subirla a la G&W." 0 0
-    clear;;
+    #sleep 5;;
+	clear;;
   D)clear
     sed -i 's/^caratula=.*$/'caratula=\""0"\"'/g' ./scene/2.2-retro-go-mario.sh
     sed -i 's/^caratula=.*$/'caratula=\""0"\"'/g' ./scene/2.2-retro-go-zelda.sh
     sed -i 's/^caratula=.*$/'caratula=\""0"\"'/g' ./scene/2.2.1-solo-retro-go-mario.sh
     sed -i 's/^caratula=.*$/'caratula=\""0"\"'/g' ./scene/2.2.1-solo-retro-go-zelda.sh
+	sed -i 's/^caratula=.*$/'caratula=\""0"\"'/g' ./scene/2.2.1-save-state-mario.sh
+    sed -i 's/^caratula=.*$/'caratula=\""0"\"'/g' ./scene/2.2.1-save-state-zelda.sh
     sed -i 's/^caratula=.*$/'caratula=\""0"\"'/g' ./scene/2.2.2-cfw-retro-go-1mb-mario.sh
     sed -i 's/^caratula=.*$/'caratula=\""0"\"'/g' ./scene/2.2.2-cfw-retro-go-4mb-zelda.sh
+	sed -i 's/^caratula=.*$/'caratula=\""0"\"'/g' ./scene/2.2.2-save-state-mario.sh
+    sed -i 's/^caratula=.*$/'caratula=\""0"\"'/g' ./scene/2.2.2-save-state-zelda.sh
     sed -i 's/^caratula=.*$/'caratula=\""0"\"'/g' ./scene/2.2.3-cfw-retro-go-16mb-mario.sh
     sed -i 's/^caratula=.*$/'caratula=\""0"\"'/g' ./scene/2.2.3-cfw-retro-go-16mb-zelda.sh
+	sed -i 's/^caratula=.*$/'caratula=\""0"\"'/g' ./scene/2.2.3-save-state-mario.sh
+    sed -i 's/^caratula=.*$/'caratula=\""0"\"'/g' ./scene/2.2.3-save-state-zelda.sh
     sed -i 's/^caratula=.*$/'caratula=\""0"\"'/g' ./scene/2.2.4-cfw-retro-go-64mb-mario.sh
     sed -i 's/^caratula=.*$/'caratula=\""0"\"'/g' ./scene/2.2.4-cfw-retro-go-64mb-zelda.sh
+	sed -i 's/^caratula=.*$/'caratula=\""0"\"'/g' ./scene/2.2.4-save-state-mario.sh
+    sed -i 's/^caratula=.*$/'caratula=\""0"\"'/g' ./scene/2.2.4-save-state-zelda.sh
     sed -i 's/^caratula=.*$/'caratula=\""0"\"'/g' ./scene/2.2.C-opcion-caratula.sh
     dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.C-opcion-caratula.sh Usuario = $usuario ------------------" \
     --title "G&W $consola menu caratulas" \
     --msgbox "Opcion caratulas DESACTIVADA. NOTA:Para flashear caratulas de roms en el menú hará falta colocar en el mismo directorio de la rom un archivo jpg, bmp o png con el mismo nombre de la rom y el propio programa se encargara de comprimirla y subirla a la G&W." 0 0
-    clear;;
+    #sleep 5;;
+	clear;;
 esac
 clear

--- a/scene/2.2.C-opcion-caratula.sh
+++ b/scene/2.2.C-opcion-caratula.sh
@@ -5,7 +5,7 @@ INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="mario"
 proc="4"
-caratula="1"
+caratula="0"
 
 dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.C-opcion-caratula.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
 --title "G&W $consola menu caratulas" \

--- a/scene/2.2.C-opcion-caratula.sh
+++ b/scene/2.2.C-opcion-caratula.sh
@@ -5,7 +5,7 @@ INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
 consola="mario"
 proc="4"
-caratula="0"
+caratula="1"
 
 dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.C-opcion-caratula.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
 --title "G&W $consola menu caratulas" \

--- a/scene/2.2.H-opcion-herramientas.sh
+++ b/scene/2.2.H-opcion-herramientas.sh
@@ -3,6 +3,7 @@
 
 INPUT=/tmp/$MENU.sh.$$
 usuario="kde"
+consola="mario"
 
 clear
 dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.H-opcion-herramientas.sh Usuario = $usuario ------------------" \
@@ -44,22 +45,41 @@ case $menuitem in
     cd -
     echo -e "\e[1;31mProceso terminado. Pulsa cualquier tecla para continuar...\e[0m"
     read -n 1 -s -r -p ""
-    dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.H-opcion-herramientas.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
-           --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
-           --msgbox "Proceso realizado. Save states descargados en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" 0 0
     ./scene/2.2.H-opcion-herramientas.sh
     clear;;
   3)clear
-    echo -e "\e[1;31mConecta la consola con el stlink y pulsa cualquier tecla para realizar el test...\e[0m"
-    read -n 1 -s -r -p ""
-    cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
-    make flash_test
-    cd -
-    echo -e "\e[1;31mProceso terminado. Pulsa cualquier tecla para continuar...\e[0m"
-    read -n 1 -s -r -p ""
-    dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.H-opcion-herramientas.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
-           --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
-           --msgbox "Proceso realizado. Save states descargados en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" 0 0
+    dialog --backtitle "G&W $consola - Herramientas y Utilidades ------------------ INFO: 2.2.H-opcion-herramientas.sh Usuario = $usuario ------------------" \
+           --title "Herramientas y utilidades G&W" \
+           --yesno "¡¡¡ATENCION!!! El programa de test de la flash externa se carga en la memoria interna para poder realizarse. Esto quiere decir que si tenemos dual boot con CFW+Retro-Go habra que habrá que reflashear el CFW porque éste será reemplazado por el programa de test de la flash. Si tenemos consola con solo Retro-Go tendremos que reflashear Retro-Go completo. Para realizar el proceso de test de la flash es necesario haber compilado Retro-Go para tu tipo de memoria de manera satisfactoria. Si no lo realizaste vuelve atras y compila Retro-Go con al menos una rom. Si ya lo hiciste prosigue con el proceso. ¿Deseas continuar?" 0 0
+    ans=$?
+    if [ $ans -eq 0 ]; then
+        clear
+        echo -e "\e[1;31mConecta la consola con el stlink y pulsa cualquier tecla para realizar el test...\e[0m"
+        read -n 1 -s -r -p ""
+        cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
+        make GNW_TARGET=$consola flash_test
+        cd -
+        echo -e "\e[1;31mProceso terminado. Pulsa cualquier tecla para continuar...\e[0m"
+        read -n 1 -s -r -p ""
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.H-opcion-herramientas.sh Usuario = $usuario ------------------" \
+               --title "INFO: Usuario=$usuario --- Menu herramientas y utilidades" \
+               --msgbox "A continuacion se realizará un make reset porque en la mayoria de los casos ayuda a poder apagar la consola despues de haber realizado el test." 0 0
+        clear
+        echo -e "\e[1;31mConecta la consola con el stlink y pulsa cualquier tecla para realizar el reset...\e[0m"
+        read -n 1 -s -r -p ""
+        cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
+        make reset
+        cd -
+        echo -e "\e[1;31mProceso terminado. Pulsa cualquier tecla para continuar...\e[0m"
+        read -n 1 -s -r -p ""
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.H-opcion-herramientas.sh Usuario = $usuario ------------------" \
+               --title "INFO: Usuario=$usuario --- Menu herramientas y utilidades" \
+               --msgbox "¡¡¡ATENCION!!! Proceso realizado, pero RECUERDA: El programa de test de la flash externa se carga en la memoria interna para poder realizarse. Esto quiere decir que si tenemos dual boot con CFW+Retro-Go habra que habrá que reflashear el CFW porque éste será reemplazado por el programa de test de la flash. Si tenemos consola con solo Retro-Go tendremos que reflashear Retro-Go completo." 0 0
+    else
+        dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.H-opcion-herramientas.sh Usuario = $usuario ------------------" \
+               --title "INFO: Usuario=$usuario --- Menu herramientas y utilidades" \
+               --msgbox "Proceso cancelado." 0 0
+    fi
     ./scene/2.2.H-opcion-herramientas.sh
     clear;;
 esac

--- a/scene/2.2.H-opcion-herramientas.sh
+++ b/scene/2.2.H-opcion-herramientas.sh
@@ -7,7 +7,7 @@ usuario="kde"
 clear
 dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.H-opcion-herramientas.sh Usuario = $usuario ------------------" \
        --title "INFO: Usuario=$usuario --- Menu herramientas y utilidades" \
-       --infobox "G&W herramientas y utilidades" 0 0 ; sleep 3
+       --infobox "G&W herramientas y utilidades" 0 0 ; sleep 1
 dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.H-opcion-herramientas.sh Usuario = $usuario ------------------" \
        --title "INFO: Usuario=$usuario --- Menu herramientas y utilidades" \
        --ok-label Apply \

--- a/scene/2.2.H-opcion-herramientas.sh
+++ b/scene/2.2.H-opcion-herramientas.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+#By julenvitoria
+
+INPUT=/tmp/$MENU.sh.$$
+usuario="kde"
+
+clear
+dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.H-opcion-herramientas.sh Usuario = $usuario ------------------" \
+       --title "INFO: Usuario=$usuario --- Menu herramientas y utilidades" \
+       --infobox "G&W herramientas y utilidades" 0 0 ; sleep 3
+dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.H-opcion-herramientas.sh Usuario = $usuario ------------------" \
+       --title "INFO: Usuario=$usuario --- Menu herramientas y utilidades" \
+       --ok-label Apply \
+       --cancel-label Exit \
+       --menu "Selecciona con las flechas la opcion deseada:" 12 140 15 \
+          1 "Abrir el actualizador del firm del stlink" \
+          2 "Realizar un make reset (realizar solo si la consola se queda en negro y no llega al menu)" \
+          3 "Realizar un flash test (para verificar la conexion con el chip de memoria)"   2>"${INPUT}"
+menuitem=$(<"${INPUT}")
+case $menuitem in
+  1)clear
+    which java > java.txt
+    if grep "/java" ./java.txt ; then
+            echo "Encontrado paquete java, se prosigue..."
+            sleep 1
+    else
+            echo "No encontrado paquete java necesario, instalando..."
+            echo " "
+            sudo apt install -y default-jdk default-jre
+            echo " "
+            echo "Instalado!!"
+            sleep 1
+    fi
+    cd instalacion/actualizador
+    sudo java -jar STLinkUpgrade.jar
+    cd -
+    ./scene/2.2.H-opcion-herramientas.sh
+    clear;;
+  2)clear
+    echo -e "\e[1;31mConecta la consola con el stlink y pulsa cualquier tecla para realizar el reset...\e[0m"
+    read -n 1 -s -r -p ""
+    cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
+    make reset
+    cd -
+    echo -e "\e[1;31mProceso terminado. Pulsa cualquier tecla para continuar...\e[0m"
+    read -n 1 -s -r -p ""
+    dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.H-opcion-herramientas.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+           --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+           --msgbox "Proceso realizado. Save states descargados en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" 0 0
+    ./scene/2.2.H-opcion-herramientas.sh
+    clear;;
+  3)clear
+    echo -e "\e[1;31mConecta la consola con el stlink y pulsa cualquier tecla para realizar el test...\e[0m"
+    read -n 1 -s -r -p ""
+    cd /home/$usuario/gameandwatch/game-and-watch-retro-go/
+    make flash_test
+    cd -
+    echo -e "\e[1;31mProceso terminado. Pulsa cualquier tecla para continuar...\e[0m"
+    read -n 1 -s -r -p ""
+    dialog --backtitle "G&W $consola - Utilidades de flasheo ------------------ INFO: 2.2.H-opcion-herramientas.sh Usuario = $usuario   ////   Consola seleccionada = $consola ------------------" \
+           --title "INFO: Usuario=$usuario --- Consola seleccionada=$consola --- Save states en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" \
+           --msgbox "Proceso realizado. Save states descargados en:/home/$usuario/gameandwatch/game-and-watch-retro-go/save_states/" 0 0
+    ./scene/2.2.H-opcion-herramientas.sh
+    clear;;
+esac
+clear


### PR DESCRIPTION
Se realizan los siguientes cambios:

1-submenus para save states en ambas consolas
2-nuevos textos en los menús para que sea más sencillo identificar por memorias
3-de añade submenu de herramientas y utilidades en todos los submenus de memoria donde se añaden las opciones de lanzar el actualizador del stlink, hacer make reset y hacer make flash_test

se prueba todo y en principio todo funciona correctamente 