### PR TITLE
Preparacion del sistema: entorno virtual python + modulos pthon + lcd shrinker

### DIFF
--- a/instalacion/1.3-preparacion-sistema.sh
+++ b/instalacion/1.3-preparacion-sistema.sh
@@ -23,7 +23,6 @@ sudo apt install -y unzip binutils-arm-none-eabi python3 libhidapi-hidraw0 libft
 sudo apt install -y add-apt-repository
 sudo add-apt-repository -y ppa:inkscape.dev/stable
 sudo apt update
-sudo apt install -y inkscape
 
 # instalar virtualenv, crear el directorio "py" y si existe borrarlo y volverlo a crear, crear un entorno virtual de python en dicho directorio e instalar los modulos de python requeridos
 echo ""

--- a/instalacion/1.3-preparacion-sistema.sh
+++ b/instalacion/1.3-preparacion-sistema.sh
@@ -16,11 +16,14 @@ clear
 #        echo "Instalado!!"
 #  sleep 1
 #fi
-sudo add-apt-repository -y ppa:inkscape.dev/stable
-sudo apt update -y
-sudo apt upgrade -y
-sudo apt install -y unzip binutils-arm-none-eabi python3 libhidapi-hidraw0 libftdi1 libftdi1-2 git python3-pip virtualenv software-properties-common inkscape
 
+sudo apt update
+sudo apt upgrade -y
+sudo apt install -y unzip binutils-arm-none-eabi python3 libhidapi-hidraw0 libftdi1 libftdi1-2 git python3-pip virtualenv software-properties-common
+sudo apt install -y add-apt-repository
+sudo add-apt-repository -y ppa:inkscape.dev/stable
+sudo apt update
+sudo apt install -y inkscape
 
 # instalar virtualenv, crear el directorio "py" y si existe borrarlo y volverlo a crear, crear un entorno virtual de python en dicho directorio e instalar los modulos de python requeridos
 echo ""

--- a/instalacion/1.3-preparacion-sistema.sh
+++ b/instalacion/1.3-preparacion-sistema.sh
@@ -16,9 +16,11 @@ clear
 #        echo "Instalado!!"
 #  sleep 1
 #fi
+sudo add-apt-repository -y ppa:inkscape.dev/stable
 sudo apt update -y
 sudo apt upgrade -y
-sudo apt install -y unzip binutils-arm-none-eabi python3 libhidapi-hidraw0 libftdi1 libftdi1-2 git python3-pip virtualenv
+sudo apt install -y unzip binutils-arm-none-eabi python3 libhidapi-hidraw0 libftdi1 libftdi1-2 git python3-pip virtualenv software-properties-common inkscape
+
 
 # instalar virtualenv, crear el directorio "py" y si existe borrarlo y volverlo a crear, crear un entorno virtual de python en dicho directorio e instalar los modulos de python requeridos
 echo ""

--- a/instalacion/1.9-menu-LCD-Game-Shrinker.sh
+++ b/instalacion/1.9-menu-LCD-Game-Shrinker.sh
@@ -22,9 +22,9 @@ case $menuitem in
     #sleep 5
     git clone https://github.com/bzhxx/LCD-Game-Shrinker
     sudo apt update
-    sudo apt install -y snapd libopenjp2-7 libtiff5 libxslt-dev libatlas-base-dev
+    sudo apt install -y snapd libopenjp2-7 libtiff5 libxslt-dev libatlas-base-dev inkscape
     sudo snap install core
-    sudo snap install inkscape
+    #sudo snap install inkscape
     cd /home/$usuario/gameandwatch/LCD-Game-Shrinker
     #antiguo metodo usado para instalar los paquetes requeridos. A partir de ubuntu 23.04 no se puede usar este metodo
     #pip3 install -r requirements.txt


### PR DESCRIPTION
Creacion de entorno virtual de python para la instalacion de modulos
mediante pip3 y su ejecucion durante el proceso. 
Preparacion del sistema para el lcd shrinker:
1- en la preparacion del sistema se instala software-properties-common
(por si no esta
instalado add-apt-repository), se instala add-apt-repository
2- en la instalación del lcd-shrinker se
instala inkscape